### PR TITLE
Added collector name attribute which is used in the sumo.conf template

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,8 @@
 
 # default sumocollector attributes
 
-
+#Collector Name if not set defaults to chef node name
+default['sumologic']['name']      = nil
 
 #Collector Activation User Credentials
 default['sumologic']['userID']    = "YOUR_EMAIL"
@@ -66,4 +67,3 @@ case platform
         default['sumologic']['downloadURL'] = ""
     
 end
-

--- a/templates/default/sumo.conf.erb
+++ b/templates/default/sumo.conf.erb
@@ -1,4 +1,4 @@
-name=<%= node.name %>
+name=<%= node['sumologic']['name'] ? node['sumologic']['name'] : node.name %>
 email=<%= node['sumologic']['userID'] %>
 password=<%= node['sumologic']['password'] %>
 sources=/etc/sumo.json


### PR DESCRIPTION
to set the collector name on installation.  If no collector name is
provided as is the default the template will fall back to using the chef
node name.
