### PR TITLE
Further cleanup source JSON

### DIFF
--- a/templates/default/sumo-debian.json.erb
+++ b/templates/default/sumo-debian.json.erb
@@ -8,9 +8,7 @@
             "multilineProcessingEnabled": false,
             "useAutolineMatching": true,
             "forceTimeZone": false,
-            "defaultDateFormat": "",
             "timeZone": "UTC",
-            "description": "",
             "category": "OS/Linux/System",
             "pathExpression": "/var/log/syslog"
         },
@@ -21,9 +19,7 @@
             "multilineProcessingEnabled": false,
             "useAutolineMatching": true,
             "forceTimeZone": false,
-            "defaultDateFormat": "",
             "timeZone": "UTC",
-            "description": "",
             "category": "OS/Linux/Security",
             "pathExpression": "/var/log/auth.log"
         }

--- a/templates/default/sumo-rhel.json.erb
+++ b/templates/default/sumo-rhel.json.erb
@@ -8,9 +8,7 @@
             "multilineProcessingEnabled": false,
             "useAutolineMatching": true,
             "forceTimeZone": false,
-            "defaultDateFormat": "",
             "timeZone": "UTC",
-            "description": "",
             "category": "OS/Linux/System",
             "pathExpression": "/var/log/messages"
         },
@@ -21,9 +19,7 @@
             "multilineProcessingEnabled": false,
             "useAutolineMatching": true,
             "forceTimeZone": false,
-            "defaultDateFormat": "",
             "timeZone": "UTC",
-            "description": "",
             "category": "OS/Linux/Security",
             "pathExpression": "/var/log/secure"
         }


### PR DESCRIPTION
I confirmed with support that `defaultDateFormat` cannot be an empty string. It seemed reasonable to cleanup description as well.

I'm running this branch in our staging environment and it worked as expected.
