### PR TITLE
Enable installation in environments which require a proxy

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,6 +49,15 @@ default['sumologic']['json_template'] = nil
 # template name from a custom sumo.conf configuration cookbook.
 default['sumologic']['conf_template'] = nil
 
+default['sumologic']['use_proxy'] = false
+default['sumologic']['proxy'] = {
+  'host' => nil,
+  'port' => nil
+}
+
+default['sumologic']['collectorTarUrl'] = 'https://collectors.sumologic.com/rest/download/tar'
+default['sumologic']['collectorTarName'] = 'sumocollector.tar.gz'
+
 #Platform Specific Attributes
 case platform
     # Currently have all linux variants using the scripted installer

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ben@sumologic.com'
 license          'Apache v2.0'
 description      'Installs/Configures sumologic-collector'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.1'
+version          '1.2.2'
 attribute 'sumologic/credentials/bag_name',
   :display_name => "Credentials bag name",
   :type => "string",
@@ -13,3 +13,5 @@ attribute 'sumologic/credentials/item_name',
   :display_name => "Credentials item name",
   :type => "string",
   :required => "required"
+
+depends 'java'

--- a/recipes/install_proxy.rb
+++ b/recipes/install_proxy.rb
@@ -1,0 +1,98 @@
+#
+# Author:: Brian Oldfield (<brian.oldfield@socrata.com>)
+# Cookbook Name:: sumologic-collector
+# Recipe:: Install Sumo Logic Collector
+#
+#
+# Copyright 2013, Sumo Logic
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Install Steps:
+# 1. Install java
+# 2. Download collector tarball
+# 3. Expand to /tmp
+# 4. Move files into place
+# 5. Drop wrapper.config template
+# 6. Start collector
+#
+# Requires /etc/sumo.conf file for automated activation
+j
+include_recipe 'java'
+include_recipe 'sumologic-collector::sumoconf'
+include_recipe 'sumologic-collector::sumojson'
+
+# TODO :: Support windows
+return unless platform != 'windows'
+
+Chef::Log.info "  Creating Sumo Logic director at #{node['sumologic']['installDir']}"
+
+directory node['sumologic']['installDir']  do
+  owner 'root'
+  group 'root'
+  mode '0755'
+  recursive true
+  action :create
+end
+
+Chef::Log.info "  Downloading Sumo Logic Collector from #{node['sumologic']['collectorTarUrl']}"
+
+remote_file "/tmp/#{node['sumologic']['collectorTarName']}" do
+  source node['sumologic']['collectorTarUrl']
+  mode '0644'
+end
+
+Chef::Log.info "  Installing Sumo Logic collector at #{node['sumologic']['installDir']}"
+
+target = node['kernel']['machine'] =~ /^i[36']86$/ ? 'linux32' : 'linux64'
+bash "Expand Sumo Collector" do
+  code <<-EOF
+  [ ! `pwd` = "/tmp" ] && cd /tmp  # I don't trust the cwd param of bash resources...
+  tar xvfz #{node['sumologic']['collectorTarName']}
+  [ ! -d sumocollector ] && echo "A problem was encountered extracting sumocollector tarball" && exit 1
+  cd sumocollector
+  mv ??.*-* #{node['sumologic']['installDir']}/  # not the most precise way of doing it, but good enough for gov't work.
+  mv config #{node['sumologic']['installDir']}/
+  cp tanuki/#{target}/wrapper #{node['sumologic']['installDir']}/
+  cp tanuki/#{target}/libwrapper.so #{node['sumologic']['installDir']}/??.*-*/bin/native/lib/
+  mv collector #{node['sumologic']['installDir']}/
+
+  cd #{node['sumologic']['installDir']}
+  chmod 554 collector
+  chmod 554 wrapper
+  ln -s #{node['sumologic']['installDir']}/collector /etc/init.d/collector
+
+  # Clean up
+  cd /tmp
+  rm #{node['sumologic']['collectorTarName']}
+  [ -d sumocollector ] && rm -rf sumocollector # it will be there, I just hate using -rf...
+  EOF
+  cwd '/tmp'
+end
+
+Chef::Log.info "  Updating wrapper.conf to use system java install and proxy settings"
+
+template "#{node['sumologic']['installDir']}/config/wrapper.conf" do
+  owner 'root'
+  group 'root'
+  mode 0644
+end
+
+Chef::Log.info "  Starting collector..."
+
+service 'collector' do
+  init_command '/etc/init.d/collector'
+  supports :start => true, :status => true, :restart => true
+  action :start
+end

--- a/templates/default/wrapper.conf.erb
+++ b/templates/default/wrapper.conf.erb
@@ -1,0 +1,230 @@
+#encoding=UTF-8
+# Configuration files must begin with a line specifying the encoding
+#  of the the file.
+
+#********************************************************************
+# Wrapper License Properties (Ignored by Community Edition)
+#********************************************************************
+# Professional and Standard Editions of the Wrapper require a valid
+#  License Key to start.  Licenses can be purchased or a trial license
+#  requested on the following pages:
+# http://wrapper.tanukisoftware.com/purchase
+# http://wrapper.tanukisoftware.com/trial
+
+# Include file problems can be debugged by removing the first '#'
+#  from the following line:
+##include.debug
+
+# The Wrapper will look for either of the following optional files for a
+#  valid License Key.  License Key properties can optionally be included
+#  directly in this configuration file.
+#include ./config/wrapper-license.conf
+
+# The following property will output information about which License Key(s)
+#  are being found, and can aid in resolving any licensing problems.
+#wrapper.license.debug=TRUE
+
+#********************************************************************
+# Wrapper Localization
+#********************************************************************
+# Specify the locale which the Wrapper should use.  By default the system
+#  locale is used.
+#wrapper.lang=en_US # en_US or ja_JP
+
+# Specify the location of the Wrapper's language resources.  If these are
+#  missing, the Wrapper will default to the en_US locale.
+wrapper.lang.folder=../lang
+
+#********************************************************************
+# Wrapper Java Properties
+#********************************************************************
+# Java Application
+#  Locate the java binary on the system PATH:
+#wrapper.java.command=java
+#  Specify a specific java binary:
+wrapper.java.command=<%= node['java']['java_home'] %>/bin/java
+
+# Tell the Wrapper to log the full generated Java command line.
+#wrapper.java.command.loglevel=INFO
+
+# Java Main class.  This class must implement the WrapperListener interface
+#  or guarantee that the WrapperManager class is initialized.  Helper
+#  classes are provided to do this for you.  See the Integration section
+#  of the documentation for details.
+wrapper.java.mainclass=org.tanukisoftware.wrapper.WrapperSimpleApp
+
+# Java Classpath (include wrapper.jar)  Add class path elements as
+#  needed starting from 1
+wrapper.java.classpath.1=./19.95-10/lib/*
+
+# Java Library Path (location of Wrapper.DLL or libwrapper.so)
+wrapper.java.library.path.1=./19.95-10/bin/native/lib
+
+# Java Bits.  On applicable platforms, tells the JVM to run in 32 or 64-bit mode.
+wrapper.java.additional.auto_bits=TRUE
+
+# Java Additional Parameters
+wrapper.java.additional.1=-XX:+UseParallelGC 
+wrapper.java.additional.2=-server
+
+# Initial Java Heap Size (in MB)
+wrapper.java.initmemory=64
+
+# Maximum Java Heap Size (in MB)
+wrapper.java.maxmemory=128
+
+# Proxy server configuration
+wrapper.java.additional.1=-XX:+UseParallelGC 
+wrapper.java.additional.2=-server
+wrapper.java.additional.3=-Dhttps.proxyHost=<%= node['sumologic']['proxy']['host'] %>
+wrapper.java.additional.4=-Dhttps.proxyPort=<%= node['sumologic']['proxy']['port'] %>
+
+# Application parameters.  Add parameters as needed starting from 1
+wrapper.app.parameter.1=com.sumologic.scala.collector.Collector
+wrapper.app.parameter.2=-b
+wrapper.app.parameter.3=installerSources/selected.json
+
+#********************************************************************
+# Wrapper Logging Properties
+#********************************************************************
+# Enables Debug output from the Wrapper.
+# wrapper.debug=TRUE
+
+# Format of output for the console.  (See docs for formats)
+wrapper.console.format=PM
+
+# Log Level for console output.  (See docs for log levels)
+wrapper.console.loglevel=INFO
+
+# Log file to use for wrapper output logging.
+wrapper.logfile=./logs/collector.out.log
+
+# Format of output for the log file.  (See docs for formats)
+wrapper.logfile.format=LPTM
+
+# Log Level for log file output.  (See docs for log levels)
+wrapper.logfile.loglevel=INFO
+
+# Maximum size that the log file will be allowed to grow to before
+#  the log is rolled. Size is specified in bytes.  The default value
+#  of 0, disables log rolling.  May abbreviate with the 'k' (kb) or
+#  'm' (mb) suffix.  For example: 10m = 10 megabytes.
+wrapper.logfile.maxsize=1m
+
+# Maximum number of rolled log files which will be allowed before old
+#  files are deleted.  The default value of 0 implies no limit.
+wrapper.logfile.maxfiles=10
+
+# Log Level for sys/event log output.  (See docs for log levels)
+wrapper.syslog.loglevel=NONE
+
+#********************************************************************
+# Wrapper Timeout Properties
+#********************************************************************
+# Number of seconds to allow between the time that the JVM reports that it is
+# stopped and the time that the JVM process actually terminates. Setting this
+# property value to "0" (zero) means never time out.
+wrapper.jvm_exit.timeout=60
+
+# Occasionally other processes may consume most of the CPU on the collector
+# box, when this happens the collector could timeout.  Increasing this from
+# 30 second default to provide more breathing space when this occurs.
+wrapper.ping.timeout=60
+
+#********************************************************************
+# Wrapper General Properties
+#********************************************************************
+# Allow for the use of non-contiguous numbered properties
+wrapper.ignore_sequence_gaps=TRUE
+
+# Title to use when running as a console
+wrapper.console.title=Sumo Logic Collector
+
+#********************************************************************
+# Wrapper JVM Checks
+#********************************************************************
+# Detect DeadLocked Threads in the JVM. (Requires Standard Edition)
+wrapper.check.deadlock=TRUE
+wrapper.check.deadlock.interval=10
+wrapper.check.deadlock.action=RESTART
+wrapper.check.deadlock.output=FULL
+
+# Out Of Memory detection.
+# (Ignore output from dumping the configuration to the console.  This is only needed by the TestWrapper sample application.)
+wrapper.filter.trigger.999=wrapper.filter.trigger.*java.lang.OutOfMemoryError
+wrapper.filter.allow_wildcards.999=TRUE
+wrapper.filter.action.999=NONE
+# (Simple match)
+wrapper.filter.trigger.1000=java.lang.OutOfMemoryError
+# (Only match text in stack traces if -XX:+PrintClassHistogram is being used.)
+#wrapper.filter.trigger.1000=Exception in thread "*" java.lang.OutOfMemoryError
+#wrapper.filter.allow_wildcards.1000=TRUE
+wrapper.filter.action.1000=RESTART
+wrapper.filter.message.1000=The JVM has run out of memory.
+
+#********************************************************************
+# Wrapper Email Notifications. (Requires Professional Edition)
+#********************************************************************
+# Common Event Email settings.
+#wrapper.event.default.email.debug=TRUE
+#wrapper.event.default.email.smtp.host=<SMTP_Host>
+#wrapper.event.default.email.smtp.port=25
+#wrapper.event.default.email.subject=[%WRAPPER_HOSTNAME%:%WRAPPER_NAME%:%WRAPPER_EVENT_NAME%] Event Notification
+#wrapper.event.default.email.sender=<Sender email>
+#wrapper.event.default.email.recipient=<Recipient email>
+
+# Configure the log attached to event emails.
+#wrapper.event.default.email.attach_log=TRUE
+#wrapper.event.default.email.maillog.lines=50
+#wrapper.event.default.email.maillog.format=LPTM
+#wrapper.event.default.email.maillog.loglevel=INFO
+
+# Enable specific event emails.
+#wrapper.event.wrapper_start.email=TRUE
+#wrapper.event.jvm_prelaunch.email=TRUE
+#wrapper.event.jvm_start.email=TRUE
+#wrapper.event.jvm_started.email=TRUE
+#wrapper.event.jvm_deadlock.email=TRUE
+#wrapper.event.jvm_stop.email=TRUE
+#wrapper.event.jvm_stopped.email=TRUE
+#wrapper.event.jvm_restart.email=TRUE
+#wrapper.event.jvm_failed_invocation.email=TRUE
+#wrapper.event.jvm_max_failed_invocations.email=TRUE
+#wrapper.event.jvm_kill.email=TRUE
+#wrapper.event.jvm_killed.email=TRUE
+#wrapper.event.jvm_unexpected_exit.email=TRUE
+#wrapper.event.wrapper_stop.email=TRUE
+
+# Specify custom mail content
+wrapper.event.jvm_restart.email.body=The JVM was restarted.
+
+Please check on its status.
+
+
+#********************************************************************
+# Wrapper Windows NT/2000/XP Service Properties
+#********************************************************************
+# WARNING - Do not modify any of these properties when an application
+#  using this configuration file has been installed as a service.
+#  Please uninstall the service before modifying this section.  The
+#  service can then be reinstalled.
+
+# Name of the service
+wrapper.name=sumo-collector
+
+# Display name of the service
+wrapper.displayname=SumoLogic Collector
+
+# Description of the service
+wrapper.description=SumoLogic Collector
+
+# Service dependencies.  Add dependencies as needed starting from 1
+wrapper.ntservice.dependency.1=
+
+# Mode in which the service is installed.  AUTO_START, DELAY_START or DEMAND_START
+wrapper.ntservice.starttype=AUTO_START
+
+# Allow the service to interact with the desktop.
+wrapper.ntservice.interactive=false
+
+wrapper.restart.reload_configuration=true


### PR DESCRIPTION
This update is restricted to non-windows environments only. It utilizes the
collector tarball available for download via

https://collectors.sumologic.com/rest/download/tar

and replaces the bundled wrapper.conf with a template that utilizes the
system java package and the supplied proxy settings.
