### PR TITLE
exposed rpmAutoStart parameter in sumo.conf

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -128,5 +128,9 @@ else
   # default['sumologic']['sumo_json_path'] = '/tmp/JSONDIR'
 end
 
+# Auto start service when installing via rpm. 
+default['sumologic']['rpmAutoStart'] = 'true'
+
+
 # Collector Restart Command
 default['sumologic']['collectorRestartCmd'] = "#{default['sumologic']['installDir']}/collector restart"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ben@sumologic.com'
 license 'Apache v2.0'
 description 'Installs/Configures sumologic-collector'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.4'
+version '1.2.5'
 attribute 'sumologic/credentials/bag_name',
   display_name: "Credentials bag name",
   type: "string",

--- a/templates/default/sumo.conf.erb
+++ b/templates/default/sumo.conf.erb
@@ -21,3 +21,4 @@ ephemeral=<%= node['sumologic']['ephemeral'] %>
 syncSources=<%=node['sumologic']['sumo_json_path']%>
 <% end -%>
 
+rpmAutoStart=<%=node['sumologic']['rpmAutoStart']%>


### PR DESCRIPTION
This change only exposes the 'rpmAutoStart' parameter in sumo.conf file.

Why do i need this ?

My client uses rpm based install and would prefer the option of start the sumo logic service after the application cookbook had finished creating sumo logic config files.

Please feel free to contact me regarding this.

Thanks
Venkat.