### PR TITLE
Add sumologic_source provider: issue #43

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -40,4 +40,14 @@ suites:
       - ubuntu-14.04
       - centos-7.1
       - centos-6.7
-      
+  - name: test_sumologic_source_create
+    run_list:
+      - recipe[sumologic_source_test::create_default]
+    excludes:
+      - windows-2012r2
+  - name: test_sumologic_source_delete
+    run_list:
+      - recipe[sumologic_source_test::create_default]
+      - recipe[sumologic_source_test::delete_default]
+    excludes:
+      - windows-2012r2

--- a/Berksfile
+++ b/Berksfile
@@ -4,4 +4,6 @@ metadata
 
 group :integration do
   cookbook 'data-bag-faker', path: 'test/fixtures/cookbooks/data-bag-faker'
+  cookbook 'sumologic_source_test',
+    path: 'test/fixtures/cookbooks/sumologic_source_test'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,27 @@
 # CHANGELOG for sumologic-collector
 
-This file is used to list changes made in each version of sumologic-collector.
+All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 0.1.0:
+## 1.3.0
+11/6/2015
+* Add `sumologic_source` provider to create or delete a [SumoLogic "sources" JSON file.][sources] See `libraries` directory to examine the new providers, and see the accompanying tests in the `test` and `spec` directories. Look at the changes to .kitchen.yml for new test integration suites.
+* Add chronologically ascending CHANGELOG.md.
 
-* Initial release of sumologic-collector
+## 1.2.6
+
+* Add support for restarting the collector on `Windows`
+
+## 1.2.5
+
+* Add basic serverspec
 
 ## 1.2.00:
 
 * Updated cookbook to support Access IDs and Keys
 * Updated cookbook to support Local Collector Management and JSON directory option.
 
-## 1.2.5
+## 0.1.0:
 
-* Add basic serverspec
+* Initial release of sumologic-collector
 
-## 1.2.6
-
-* Add support for restarting the collector on `Windows`
-
-
-- - -
-Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.
-
-The [Github Flavored Markdown page](http://github.github.com/github-flavored-markdown/) describes the differences between markdown on github and standard markdown.
+[sources]: https://service.sumologic.com/help/Using_JSON_to_configure_Sources.htm

--- a/README.md
+++ b/README.md
@@ -24,18 +24,18 @@ Note
 Starting from 19.107, there are 2 major extensions to SumoLogic collectors:
 * You can configure a collector's parameters from a set of json files under a common folder. Each of the json file will represent a source on that collector. Updates made to a json file will then be reflected on its corresponding source. Note that the format of this kind of file is **slightly different** from that of the traditional single json file (sumo.json) and they are **not** compatible. You also need to use the parameter `syncSources` instead of `sources` inside `sumo.conf`. See more details [here](https://service.sumologic.com/help/Default.htm#Using_sumo.conf.htm).
 * You can change a collector's existing parameters through local configuration json file(s) continuously. Before this, using collector API was the only option. More information about this is [here](https://service.sumologic.com/help/Default.htm#Using_Local_Configuration_File_Management.htm)
- 
+
 Installation
 ------------
 1. Create an [Access Key](http://help.sumologic.com/i19.69v2/Default.htm#Generating_Collector_Installation_API_Keys.htm)
 2. Install the cookbook in your Chef repo (your knife version should be at least 11.10.4 and you should have the [knife github plugin](https://github.com/websterclay/knife-github-cookbooks) installed):
-```knife cookbook github install SumoLogic/sumologic-collector-chef-cookbook``` 
+```knife cookbook github install SumoLogic/sumologic-collector-chef-cookbook```
 3. Specify data bag and item with your access credentials.  The data item should
 contain attributes `accessID` and `accessKey`.  Note that attribute names are case sensitive.  If the cases mismatch, the values will not appear when chef-client runs.  The default data bag/item is
 `['sumo-creds']['api-creds']`
-4. (Optional) Decide if you want to use the Local Configuration Management feature by setting the attribute `default['sumologic']['local_management']` properly. By default this feature is on, to leverage the power of Chef. 
+4. (Optional) Decide if you want to use the Local Configuration Management feature by setting the attribute `default['sumologic']['local_management']` properly. By default this feature is on, to leverage the power of Chef.
 5. (Optional) Select the json configuration option (i.e. through a single file or a folder) by setting the attribute `default['sumologic']['use_json_path_dir']` appropriately. By default a single json file is used.
-6. (Optional) Check if the path to the json file or the json folder is set correctly in the attribute `default['sumologic']['sumo_json_path']`. By default this is the path to the json file at `/etc/sumo.json` on Linux or `c:\sumo\sumo.json` on Windows. 
+6. (Optional) Check if the path to the json file or the json folder is set correctly in the attribute `default['sumologic']['sumo_json_path']`. By default this is the path to the json file at `/etc/sumo.json` on Linux or `c:\sumo\sumo.json` on Windows.
 7. Upload the cookbook to your Chef Server:
 ```knife cookbook upload sumologic-collector```
 8. Add the `sumologic-collector` receipe to your node run lists.  This step depends
@@ -78,6 +78,10 @@ Attributes
   </tr>
 </table>
 
+### To use the `sumologic_source` provider
+
+Version 1.3.0 adds a new provider to create one or more [SumoLogic "sources" JSON files.][sources] configuration file. To learn how to use the provider, please refer to both the `libraries` directory and the test recipes in `test/fixtures/cookbooks/sumologic_source_test`.
+
 Contributing
 ------------
 This cookbook is meant to help customers use Chef to install Sumo Logic
@@ -89,3 +93,5 @@ License and Authors
 -------------------
 Authors:
 	Ben Newton (ben@sumologic.com), Duc Ha (duc@sumologic.com)
+
+[sources]: https://service.sumologic.com/help/Using_JSON_to_configure_Sources.htm

--- a/libraries/chef_provider_sumologic_source.rb
+++ b/libraries/chef_provider_sumologic_source.rb
@@ -2,6 +2,7 @@ require 'chef/provider/lwrp_base'
 
 class Chef
   class Provider
+    # Provider to create or delete a Sumologic "source" configuration file
     class SumologicSource < Chef::Provider::LWRPBase
       provides :sumologic_source if defined?(provides)
 

--- a/libraries/chef_provider_sumologic_source.rb
+++ b/libraries/chef_provider_sumologic_source.rb
@@ -1,0 +1,39 @@
+require 'chef/provider/lwrp_base'
+
+class Chef
+  class Provider
+    class SumologicSource < Chef::Provider::LWRPBase
+      provides :sumologic_source if defined?(provides)
+
+      use_inline_resources if defined?(use_inline_resources)
+
+      def whyrun_supported?
+        true
+      end
+
+      action :create do
+        directory ::File.dirname new_resource.name do
+          owner new_resource.owner
+          group new_resource.group
+          mode new_resource.mode
+          recursive true
+        end
+
+        template new_resource.name do
+          owner new_resource.owner
+          group new_resource.group
+          mode new_resource.mode
+          variables(new_resource.variables)
+          source new_resource.source
+          cookbook new_resource.cookbook
+        end
+      end
+
+      action :delete do
+        file new_resource.name do
+          action :delete
+        end
+      end
+    end
+  end
+end

--- a/libraries/chef_resource_sumologic_source.rb
+++ b/libraries/chef_resource_sumologic_source.rb
@@ -1,0 +1,20 @@
+require 'chef/resource/lwrp_base'
+
+class Chef
+  class Resource
+    class SumologicConfig < Chef::Resource::LWRPBase
+      provides :sumologic_source if defined? provides
+
+      self.resource_name = :sumologic_source
+      actions :create, :delete
+      default_action :create
+
+      attribute :owner, kind_of: String, default: 'root'
+      attribute :group, kind_of: String, default: 'root'
+      attribute :mode, kind_of: String, default: '0640'
+      attribute :variables, kind_of: [Hash], default: nil
+      attribute :source, kind_of: String, default: nil
+      attribute :cookbook, kind_of: String, default: nil
+    end
+  end
+end

--- a/libraries/chef_resource_sumologic_source.rb
+++ b/libraries/chef_resource_sumologic_source.rb
@@ -2,6 +2,7 @@ require 'chef/resource/lwrp_base'
 
 class Chef
   class Resource
+    # Resource to create or delete a Sumologic "source" configuration file
     class SumologicConfig < Chef::Resource::LWRPBase
       provides :sumologic_source if defined? provides
 

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,12 +1,12 @@
 if defined? ChefSpec
   ChefSpec.define_matcher :sumologic_source
 
-  def create_sumologic_source resource_name
+  def create_sumologic_source(resource_name:)
     ChefSpec::Matchers::ResourceMatcher.new :sumologic_source, :create,
       resource_name
   end
 
-  def delete_sumologic_source resource_name
+  def delete_sumologic_source(resource_name:)
     ChefSpec::Matchers::ResourceMatcher.new :sumologic_source, :delete,
       resource_name
   end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,13 @@
+if defined? ChefSpec
+  ChefSpec.define_matcher :sumologic_source
+
+  def create_sumologic_source resource_name
+    ChefSpec::Matchers::ResourceMatcher.new :sumologic_source, :create,
+      resource_name
+  end
+
+  def delete_sumologic_source resource_name
+    ChefSpec::Matchers::ResourceMatcher.new :sumologic_source, :delete,
+      resource_name
+  end
+end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,12 +1,12 @@
 if defined? ChefSpec
   ChefSpec.define_matcher :sumologic_source
 
-  def create_sumologic_source(resource_name:)
+  def create_sumologic_source(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new :sumologic_source, :create,
       resource_name
   end
 
-  def delete_sumologic_source(resource_name:)
+  def delete_sumologic_source(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new :sumologic_source, :delete,
       resource_name
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+at_exit { ChefSpec::Coverage.report! }

--- a/spec/sumologic_source/default/create_default_spec.rb
+++ b/spec/sumologic_source/default/create_default_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'sumologic_source_test::create_default' do
+  cached(:chef_run) do
+    runner = ChefSpec::SoloRunner.new step_into: ['sumologic_source']
+    runner.converge described_recipe
+  end
+  subject { chef_run }
+
+  it { is_expected.to include_recipe 'sumologic_source_test::create_default' }
+  it { is_expected.to create_directory ::File.dirname '/etc/sumo.d/sumo.json' }
+  it { is_expected.to create_template '/etc/sumo.d/sumo.json' }
+  it { is_expected.to create_sumologic_source '/etc/sumo.d/sumo.json' }
+end

--- a/spec/sumologic_source/default/delete_default_spec.rb
+++ b/spec/sumologic_source/default/delete_default_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'sumologic_source_test::delete_default' do
+  cached(:chef_run) do
+    runner = ChefSpec::SoloRunner.new step_into: ['sumologic_source']
+    runner.converge described_recipe
+  end
+  subject { chef_run }
+
+  it { is_expected.to include_recipe 'sumologic_source_test::delete_default' }
+  it { is_expected.to create_directory ::File.dirname '/etc/sumo.d/sumo.json' }
+  it { is_expected.to create_template '/etc/sumo.d/sumo.json' }
+
+  it do
+    is_expected.to_not delete_directory ::File.dirname '/etc/sumo.d/sumo.json'
+  end
+
+  it { is_expected.to delete_file '/etc/sumo.d/sumo.json' }
+  it { is_expected.to delete_sumologic_source '/etc/sumo.d/sumo.json' }
+end

--- a/spec/sumologic_source/default/delete_default_spec.rb
+++ b/spec/sumologic_source/default/delete_default_spec.rb
@@ -8,8 +8,6 @@ describe 'sumologic_source_test::delete_default' do
   subject { chef_run }
 
   it { is_expected.to include_recipe 'sumologic_source_test::delete_default' }
-  it { is_expected.to create_directory ::File.dirname '/etc/sumo.d/sumo.json' }
-  it { is_expected.to create_template '/etc/sumo.d/sumo.json' }
 
   it do
     is_expected.to_not delete_directory ::File.dirname '/etc/sumo.d/sumo.json'

--- a/test/fixtures/cookbooks/sumologic_source_test/metadata.rb
+++ b/test/fixtures/cookbooks/sumologic_source_test/metadata.rb
@@ -1,0 +1,3 @@
+name 'sumologic_source_test'
+version '0.0.0'
+depends 'sumologic-collector'

--- a/test/fixtures/cookbooks/sumologic_source_test/recipes/create_default.rb
+++ b/test/fixtures/cookbooks/sumologic_source_test/recipes/create_default.rb
@@ -1,0 +1,3 @@
+sumologic_source '/etc/sumo.d/sumo.json' do
+  action :create
+end

--- a/test/fixtures/cookbooks/sumologic_source_test/recipes/delete_default.rb
+++ b/test/fixtures/cookbooks/sumologic_source_test/recipes/delete_default.rb
@@ -1,7 +1,3 @@
 sumologic_source '/etc/sumo.d/sumo.json' do
-  action :create
-end
-
-sumologic_source '/etc/sumo.d/sumo.json' do
   action :delete
 end

--- a/test/fixtures/cookbooks/sumologic_source_test/recipes/delete_default.rb
+++ b/test/fixtures/cookbooks/sumologic_source_test/recipes/delete_default.rb
@@ -1,0 +1,7 @@
+sumologic_source '/etc/sumo.d/sumo.json' do
+  action :create
+end
+
+sumologic_source '/etc/sumo.d/sumo.json' do
+  action :delete
+end

--- a/test/fixtures/cookbooks/sumologic_source_test/templates/default/sumo.json.erb
+++ b/test/fixtures/cookbooks/sumologic_source_test/templates/default/sumo.json.erb
@@ -1,0 +1,21 @@
+{
+    "api.version": "v1",
+    "sources": [
+        {
+            "sourceType": "LocalFile",
+            "name": "Example1",
+            "pathExpression": "/var/logs/maillog",
+            "blacklist": [
+                "/var/log/*log1.log"
+            ],
+            "category": "mail",
+            "hostName": "sampleSource",
+            "useAutolineMatching": false,
+            "multilineProcessingEnabled": false,
+            "timeZone": "America/Los_Angeles",
+            "automaticDateParsing": true,
+            "forceTimeZone": false,
+            "defaultDateFormat": "dd/MMM/yyyy HH:mm:ss"
+        }
+    ]
+}

--- a/test/integration/test_sumologic_source_create/serverspec/sumologic_source_create_spec.rb
+++ b/test/integration/test_sumologic_source_create/serverspec/sumologic_source_create_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe file '/etc/sumo.d' do
+  it { should exist }
+  it { should be_directory }
+end
+
+describe file '/etc/sumo.d/sumo.json' do
+  it { should exist }
+end

--- a/test/integration/test_sumologic_source_delete/serverspec/sumologic_source_delete_spec.rb
+++ b/test/integration/test_sumologic_source_delete/serverspec/sumologic_source_delete_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe file '/etc/sumo.d/sumo.json' do
+  it { should_not exist }
+end


### PR DESCRIPTION
Addresses Issue #43.
---

Adds new provider, `sumologic_source`, with actions `:create` and `:delete`.

- `:create` simply drops a template given a set of parameters. This puts the onus of JSON creation back on the consumer cookbook, where it belongs. The consumer cookbook should be responsible for generating, writing, and verifying the JSON as a valid configuration for the service. (I believe SumoLogic fails silently when a configuration file is bad.) There is room for debate on where the validation should occur.
- When we create a source, we recursively create the directory that it's in, but when we delete a source, we don't delete the directory. A probably good change may be to fail if the directory doesn't exist, and then leave it up to the consumer to create the directory.
- I did not add test suites for Windows! If this is desired, then I need to have a discussion about the current test suites, which don't converge for me on the Windows platform.
- TL;DR This is a pretty dumb provider that just drops a template. I've allowed the consumer to pass the `cookbook` value into the provider to kick the ball down the road as far as templates are concerned.

@RoboticCheese @lmickh @kennonkwok
