### PR TITLE
Ensure sumo-collector is running

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,6 +38,9 @@ if File.exist? node['sumologic']['installDir']
 #	include_recipe 'sumologic-collector::sumojson'
 # end
 # include_recipe 'sumologic-collector::restart'
+  service "sumo-collector" do
+    action :start
+  end
 else
   Chef::Log.info "Installing Sumo Logic Collector..."
   include_recipe 'sumologic-collector::sumoconf'


### PR DESCRIPTION
We ran into an issue where the Sumo Collector would successfully install but ran into connectivity issues and therefore the service stopped. Ideally if our cookbooks require Sumo to be installed, then we'd expect the service to be started in the event of some unforeseen service stop event.