### PR TITLE
Bug fix windows install

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ben@sumologic.com'
 license 'Apache v2.0'
 description 'Installs/Configures sumologic-collector'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.6'
+version '1.2.7'
 attribute 'sumologic/credentials/bag_name',
   display_name: "Credentials bag name",
   type: "string",

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -32,8 +32,18 @@
 # https://service.sumologic.com/ui/help/Default.htm#JSON_Source_Configuration.htm
 #
 
-if File.exist? node['sumologic']['installDir']
+if ::Win32::Service.exist? "Sumologic-Collector"
   Chef::Log.info "Sumo Logic Collector found."
+  Chef::Log.info "Checking for Sumo Logic Collector Updates and will "\
+    "reinstall director at #{node['sumologic']['installDir']}"
+
+  # We only want to deploy sumo when there's a new version available
+  # to preserve idempotency .
+  remote_file "#{node['sumologic']['installDir']}/#{node['sumologic']['installerName']}" do
+    source node['sumologic']['downloadURL']
+    notifies :run, 'execute[Deploy Sumo Collector]', :immediately
+  end
+
 # If collector is already in sync source mode, just uncomment these following lines to update the sources
 # include_recipe 'sumologic-collector::sumoconf'
 # if node['sumologic']['use_json_path_dir'] == true
@@ -55,6 +65,8 @@ else
     include_recipe 'sumologic-collector::sumojson'
   end
   
+  Chef::Log.info "Installing Sumo Logic director at #{node['sumologic']['installDir']}"
+
   # We only want to deploy sumo when there's a new version available
   # to preserve idempotency .
   remote_file "#{node['sumologic']['installDir']}/#{node['sumologic']['installerName']}" do
@@ -62,15 +74,15 @@ else
     notifies :run, 'execute[Deploy Sumo Collector]', :immediately
   end
 
-  Chef::Log.info "  Installing Sumo Logic director at #{node['sumologic']['installDir']}"
-
-  execute "Deploy Sumo Collector" do
-    command node['sumologic']['installerCmd']
-    cwd node['sumologic']['installDir']
-    timeout 3600
-    action :nothing
-  end
 
   # The following recipe will clean up sumo.conf and the json configuration file(s). Use it if you only need to setup the collector once.
   # include_recipe 'sumologic-collector::cleanup'
+end
+
+
+execute "Deploy Sumo Collector" do
+  command node['sumologic']['installerCmd']
+  cwd node['sumologic']['installDir']
+  timeout 3600
+  action :nothing
 end

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -55,9 +55,11 @@ else
     include_recipe 'sumologic-collector::sumojson'
   end
   
+  # We only want to deploy sumo when there's a new version available
+  # to preserve idempotency .
   remote_file "#{node['sumologic']['installDir']}/#{node['sumologic']['installerName']}" do
     source node['sumologic']['downloadURL']
-
+    notifies :run, 'execute[Deploy Sumo Collector]', :immediately
   end
 
   Chef::Log.info "  Installing Sumo Logic director at #{node['sumologic']['installDir']}"
@@ -66,6 +68,7 @@ else
     command node['sumologic']['installerCmd']
     cwd node['sumologic']['installDir']
     timeout 3600
+    action :nothing
   end
 
   # The following recipe will clean up sumo.conf and the json configuration file(s). Use it if you only need to setup the collector once.

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -32,7 +32,7 @@
 # https://service.sumologic.com/ui/help/Default.htm#JSON_Source_Configuration.htm
 #
 
-if ::Win32::Service.exist? "Sumologic-Collector"
+if ::Win32::Service.exists? "Sumologic-Collector"
   Chef::Log.info "Sumo Logic Collector found."
   Chef::Log.info "Checking for Sumo Logic Collector Updates and will "\
     "reinstall director at #{node['sumologic']['installDir']}"
@@ -74,11 +74,9 @@ else
     notifies :run, 'execute[Deploy Sumo Collector]', :immediately
   end
 
-
   # The following recipe will clean up sumo.conf and the json configuration file(s). Use it if you only need to setup the collector once.
   # include_recipe 'sumologic-collector::cleanup'
 end
-
 
 execute "Deploy Sumo Collector" do
   command node['sumologic']['installerCmd']

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -32,7 +32,7 @@
 # https://service.sumologic.com/ui/help/Default.htm#JSON_Source_Configuration.htm
 #
 
-if ::Win32::Service.exists? "Sumologic-Collector"
+if ::Win32::Service.exists? "sumo-collector"
   Chef::Log.info "Sumo Logic Collector found."
   Chef::Log.info "Checking for Sumo Logic Collector Updates and will "\
     "reinstall director at #{node['sumologic']['installDir']}"


### PR DESCRIPTION
The goal of this PR is to make the windows install idempotent and a bit better at detecting whether or not the collector is legitimately installed.

- Instead of using the base install directory for the collector - detect whether the 'sumo-collector' service exists to decide whether it is currently installed.
- Change logic to suit idempotent behavior:
   - Only run the installer if the following are true:
       1. The service does not exist (new install)
       2. There is a change in the collector payload, which reflects a newer version - let's update it.
- Change how the execute resource behaves to reflect the above changes.

I tested the above on an internal server.  I found it difficult to work with the current test setup via the Rakefile.