### PR TITLE
sumologic-collector improvements

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -37,17 +37,13 @@ action :configure do
   if !@current_resource.installed
     Chef::Log.info "Collector Directory is not found at #{new_resource.dir}. Will not do anything."
   else
+    sumo_service
     template "#{new_resource.dir}/config/user.properties" do
       source 'user.properties.erb'
       cookbook 'sumologic-collector'
       variables resource: new_resource
       sensitive true
-    end
-    execute 'Restart SumoLogic Collector' do
-      command restart_cmd
-      cwd new_resource.dir
-      action :nothing
-      subscribes :run, "template[#{new_resource.dir}/config/user.properties]" unless new_resource.skip_restart
+      notifies :restart, 'service[sumo-collector]', :immediately unless new_resource.skip_restart
     end
   end
 end
@@ -68,10 +64,7 @@ action :start do
   if !@current_resource.installed
     Chef::Log.info "Collector Directory is not found at #{new_resource.dir}. Will not do anything."
   else
-    execute 'Start SumoCollector' do
-      command start_cmd
-      cwd new_resource.dir
-    end
+    sumo_service :start
   end
 end
 
@@ -79,10 +72,7 @@ action :stop do
   if !@current_resource.installed
     Chef::Log.info "Collector Directory is not found at #{new_resource.dir}. Will not do anything."
   else
-    execute 'Stop SumoCollector' do
-      command stop_cmd
-      cwd new_resource.dir
-    end
+    sumo_service :stop
   end
 end
 
@@ -90,37 +80,7 @@ action :restart do
   if !@current_resource.installed
     Chef::Log.info "Collector Directory is not found at #{new_resource.dir}. Will not do anything."
   else
-    execute 'Restart SumoCollector' do
-      command restart_cmd
-      cwd new_resource.dir
-    end
-  end
-end
-
-def restart_cmd
-  case node['platform_family']
-  when 'windows'
-    "#{stop_cmd} && #{start_cmd}"
-  else
-    './collector restart'
-  end
-end
-
-def start_cmd
-  case node['platform_family']
-  when 'windows'
-    'net start "sumo-collector"'
-  else
-    './collector start'
-  end
-end
-
-def stop_cmd
-  case node['platform_family']
-  when 'windows'
-    'net stop "sumo-collector"'
-  else
-    './collector stop'
+    sumo_service :restart
   end
 end
 
@@ -164,6 +124,13 @@ def run_installer(installer_cmd)
   execute 'Install Sumo Collector' do
     command "#{Chef::Config[:file_cache_path]}/#{installer_cmd}"
     timeout 3600
+  end
+end
+
+def sumo_service(action = :nothing)
+  service 'sumo-collector' do
+    service_name 'collector' unless node['platform_family'] == 'windows'
+    action action
   end
 end
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -84,6 +84,22 @@ action :restart do
   end
 end
 
+action :enable do
+  if !@current_resource.installed
+    Chef::Log.info "Collector Directory is not found at #{new_resource.dir}. Will not do anything."
+  else
+    sumo_service :enable
+  end
+end
+
+action :disable do
+  if !@current_resource.installed
+    Chef::Log.info "Collector Directory is not found at #{new_resource.dir}. Will not do anything."
+  else
+    sumo_service :disable
+  end
+end
+
 private
 
 def installed?

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -3,7 +3,7 @@
 
 default_action :install_and_configure
 
-actions :install, :install_and_configure, :configure, :remove, :start, :stop, :restart
+actions :install, :install_and_configure, :configure, :remove, :start, :stop, :restart, :enable, :disable
 
 # Installation attributes
 attribute :dir, kind_of: String, name_attribute: true

--- a/templates/default/user.properties.erb
+++ b/templates/default/user.properties.erb
@@ -30,4 +30,4 @@ name=<%= @resource.collector_name %>
 <%= "syncSources=#{@resource.sync_sources}" unless @resource.sync_sources.nil? %>
 <%= "ephemeral=#{@resource.ephemeral}" unless @resource.ephemeral.nil? %>
 <%= "clobber=#{@resource.clobber}" unless @resource.clobber.nil? %>
-<%= "disableScriptSource=#{@disable_script_source}" unless @resource.disable_script_source.nil? %>
+<%= "disableScriptSource=#{@resource.disable_script_source}" unless @resource.disable_script_source.nil? %>

--- a/test/fixtures/cookbooks/default-resource/recipes/default.rb
+++ b/test/fixtures/cookbooks/default-resource/recipes/default.rb
@@ -3,5 +3,6 @@ sumo_dir = node['platform_family'] == 'windows' ? 'c:\sumo' : '/opt/SumoCollecto
 sumologic_collector sumo_dir do
   sumo_access_id node['SUMO_ACCESS_ID']
   sumo_access_key node['SUMO_ACCESS_KEY']
+  ephemeral true
   skip_registration true
 end


### PR DESCRIPTION
This PR includes a few changes for the `sumologic-collector` resource:

* Fixes a bug in the `user.properties` template that would cause the `configure` action to output an invalid file.
* Switched to using the `service` resource to avoid using `execute` blocks
* Added `enable` and `disable` actions to make `sumologic-collector` fully like a service
* Modified the kitchen tests so that the recipes that can register a collector, use the `ephemeral` attribute