### PR TITLE
Fix service name based on platform (win vs linux)

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,9 +38,17 @@ if File.exist? node['sumologic']['installDir']
 #	include_recipe 'sumologic-collector::sumojson'
 # end
 # include_recipe 'sumologic-collector::restart'
-  service "collector" do
-    action :start
+  case node['platform_family']
+  when 'rhel', 'amazon', 'linux', 'debian'
+    service 'collector' do
+      action :start
+    end
+  else
+    service 'sumo-collector' do
+      action :start
+    end
   end
+
 else
   Chef::Log.info "Installing Sumo Logic Collector..."
   include_recipe 'sumologic-collector::sumoconf'


### PR DESCRIPTION
Check platform to decide whether the right service name is collector or sumo-collector. The windows implementation currently fails because you do service "collector" while on windows it is called sumo-collector.

Thanks