### PR TITLE
sumo_source_docker attribute name is collect_events, not collected_events

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ listed above.
 - `all_containers`
 - `cert_path`
 - `source_type` - one of `:docker_stats`, `:docker_log`. **required**
-- `collected_events`
+- `collect_events`
 
 ### Examples
 


### PR DESCRIPTION
The [docker source resource](https://github.com/SumoLogic/sumologic-collector-chef-cookbook/blob/master/libraries/resource_docker_source.rb#L12) defines the attribute as `collect_events`, but the [readme](https://github.com/SumoLogic/sumologic-collector-chef-cookbook/blob/master/README.md#attribute-parameters-3) calls the attribute `collected_events`.

If you do try to use `collected_events`, you get a chef compilation error:
```
NoMethodError
-------------
undefined method `collected_events' for Chef::Resource::SumoSourceDocker
```