### PR TITLE
fix collect events type in docker source

### DIFF
--- a/libraries/resource_docker_source.rb
+++ b/libraries/resource_docker_source.rb
@@ -9,7 +9,7 @@ class Chef
       attribute :specified_containers, kind_of: Array
       attribute :all_containers, kind_of: [TrueClass, FalseClass], required: true
       attribute :cert_path, kind_of: String
-      attribute :collect_events, kind_of: String
+      attribute :collect_events, kind_of: [TrueClass, FalseClass]
     end
   end
 end


### PR DESCRIPTION
[documentation](https://help.sumologic.com/Send_Data/Sources/Use_JSON_to_Configure_Sources#Docker_Log_Source) details that the collectEvents parameter should be a boolean type

resolves https://github.com/SumoLogic/sumologic-collector-chef-cookbook/issues/78