### PR TITLE
Add service retries attempts and delays

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -146,6 +146,8 @@ end
 def sumo_service(action = :nothing)
   service 'sumo-collector' do
     service_name 'collector' unless node['platform_family'] == 'windows'
+    retries service_retries
+    retry_delay service_retry_delay
     action action
   end
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -15,6 +15,8 @@ attribute :skip_registration, kind_of: [TrueClass, FalseClass], default: false
 # Configuration attributes
 attribute :collector_name, kind_of: String, default: nil
 attribute :collector_url, kind_of: String, default: nil
+attribute :service_retries, kind_of: Integer, default: 0
+attribute :service_retry_delay, kind_of: Integer, default: 2
 attribute :sumo_email, kind_of: String, default: nil
 attribute :sumo_password, kind_of: String, default: nil
 attribute :sumo_token_and_url, kind_of: String, default: nil


### PR DESCRIPTION
The [service resource](https://docs.chef.io/resource_service.html)  provides attributes `retries` and `retry_delay`. This PR adds support for the `sumologic_collector` to expose these as attributes `service_retries` and `service_retry_delay` respectively.

I have set the defaults for the `sumologic_collector` to the default for the [service resource](https://docs.chef.io/resource_service.html).

