### PR TITLE
Add prerequisite files to run style checks and unit tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+# Use Travis's cointainer based infrastructure
+sudo: false
+
+language: ruby
+# Travis: Bundler that comes with Ruby 2.1.0 is too old (1.6.9)
+before_install: gem update bundler
+bundler_args: --without kitchen_vagrant
+rvm:
+- 2.1.0
+script:
+- bundle exec rake travis

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,18 @@
+source "https://rubygems.org"
+
+gem "chef"
+gem "chefspec"
+gem "test-kitchen"
+gem "kitchen-vagrant"
+gem "kitchen-inspec"
+
+group :lint do
+  gem "foodcritic"
+  gem "rubocop"
+  gem "rainbow"
+end
+
+group :unit do
+  gem "berkshelf"
+  gem "fauxhai"
+end

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 sumologic-collector Cookbook
 ============================
+[![Cookbook Version](https://img.shields.io/cookbook/v/sumologic-collector.svg?style=flat)](https://supermarket.chef.io/cookbooks/sumologic-collector)
+[![Build Status](https://travis-ci.org/SumoLogic/sumologic-collector-chef-cookbook.svg?branch=master)](https://travis-ci.org/SumoLogic/sumologic-collector-chef-cookbook)
+
 This cookbook installs the Sumo Logic collector or updates an existing one if it was set to use [Local Configuration Mangement](https://service.sumologic.com/help/Default.htm#Using_Local_Configuration_File_Management.htm). Installation on Linux uses the shell script
 installer and on Windows uses the exe installer. Here are the steps it follows:
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-gem 'rubocop', '>=0.33.0'
-
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'foodcritic'


### PR DESCRIPTION
This should improve public confidence that this cookbook works as intended.

The Travis builds will fail due to Rubocop offenses - as seen with the status checks below - however those can be resolved in another pull request.