### PR TITLE
Fixed deprecated features used warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ language: ruby
 before_install: gem update bundler
 bundler_args: --without kitchen_vagrant
 rvm:
-- 2.2.0
+- 2.1.0
 script:
 - bundle exec rake travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ language: ruby
 before_install: gem update bundler
 bundler_args: --without kitchen_vagrant
 rvm:
-- 2.1.0
+- 2.2.0
 script:
 - bundle exec rake travis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of sumologic-collector.
 
+## 1.2.18
+* Fixed deprecated features used warning for node on attributes/default.rb
+
 ## 1.2.17
 * Merged PR#85,86 : Add service retries attempts and delays, fixed online help doc link.
 
@@ -9,7 +12,7 @@ This file is used to list changes made in each version of sumologic-collector.
 * Merged PR#76,77: Fix [issue 61](https://github.com/SumoLogic/sumologic-collector-chef-cookbook/issues/61) and Chef 11 incompatibility in metadata.rb
 
 ## 1.2.14
-* Merged PR#74: Add :disable  and :enable action to sumologic-collector, among other things. 
+* Merged PR#74: Add :disable  and :enable action to sumologic-collector, among other things.
 
 ## 1.2.13
 * Merged PR#72: Use the net command to restart, start, and stop the
@@ -33,9 +36,9 @@ This file is used to list changes made in each version of sumologic-collector.
 
 ## 1.2.7
 02/19/2016
-* Add action for debian 8.X 
-* Add support for ChefVault 
-* Ensure sumo-collector is running 
+* Add action for debian 8.X
+* Add support for ChefVault
+* Ensure sumo-collector is running
 
 ## 1.2.6
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "chefspec"
 gem "test-kitchen"
 gem "kitchen-vagrant"
 gem "kitchen-inspec"
+gem "buff-extensions", "1.0.0"
 
 group :lint do
   gem "foodcritic"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -69,7 +69,7 @@ default['sumologic']['collectorRPMUrl'] = 'https://collectors.sumologic.com/rest
 default['sumologic']['collectorDEBUrl'] = 'https://collectors.sumologic.com/rest/download/deb/64'
 
 # Platform Specific Attributes
-case platform
+case node['platform']
 # Currently have all linux variants using the scripted installer
 when 'redhat', 'centos', 'scientific', 'fedora', 'suse', 'amazon', 'oracle', 'debian', 'ubuntu', 'linux'
   # Install Path

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ source_url 'https://github.com/SumoLogic/sumologic-collector-chef-cookbook' if r
 license 'Apache v2.0'
 description 'Installs/Configures sumologic-collector'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.17'
+version '1.2.18'
 attribute 'sumologic/credentials/bag_name',
   display_name: "Credentials bag name",
   type: "string",


### PR DESCRIPTION
I was getting the following warning:

```
Deprecated features used!
  method access to node attributes (node.foo.bar) is deprecated and will be removed in Chef 13, please use bracket syntax (node["foo"]["bar"]) at 1 location:
    - /tmp/kitchen/cache/cookbooks/sumologic-collector/attributes/default.rb:73:in `from_file'
```

I noticed it was because `case platform` was being used rather than `case node['platform']`

Updated this change and the warning disappeared.

Updated CHANGELOG.md and metadata.rb files accordingly.