### PR TITLE
fixed deprecated features used warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "chefspec"
 gem "test-kitchen"
 gem "kitchen-vagrant"
 gem "kitchen-inspec"
+gem "buff-extensions", "1.0.0"
 
 group :lint do
   gem "foodcritic"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -69,7 +69,7 @@ default['sumologic']['collectorRPMUrl'] = 'https://collectors.sumologic.com/rest
 default['sumologic']['collectorDEBUrl'] = 'https://collectors.sumologic.com/rest/download/deb/64'
 
 # Platform Specific Attributes
-case platform
+case node['platform']
 # Currently have all linux variants using the scripted installer
 when 'redhat', 'centos', 'scientific', 'fedora', 'suse', 'amazon', 'oracle', 'debian', 'ubuntu', 'linux'
   # Install Path


### PR DESCRIPTION
I was getting the following warning:

```
Deprecated features used!
  method access to node attributes (node.foo.bar) is deprecated and will be removed in Chef 13, please use bracket syntax (node["foo"]["bar"]) at 1 location:
    - /tmp/kitchen/cache/cookbooks/sumologic-collector/attributes/default.rb:73:in `from_file'
```

I noticed it was because case platform was being used rather than case node['platform']

Chef client still ships with rvm 2.1.x so I had to pin buff-extensions to version 1.0.0

Warning disappeared after this change.
