### PR TITLE
Use ChefDK on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
 script:
   - /opt/chefdk/embedded/bin/chef --version
   - /opt/chefdk/embedded/bin/rubocop --version
-  - /opt/chefdk/embedded/bin/rubocop
+  - /opt/chefdk/embedded/bin/rubocop --fail-level warning
   - /opt/chefdk/embedded/bin/foodcritic --version
   - /opt/chefdk/embedded/bin/foodcritic . --exclude spec
   - /opt/chefdk/embedded/bin/rspec --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ sudo: false
 addons:
   apt:
     sources:
-      - chef-current-precise
+      - chef-current-trusty
     packages:
       - chefdk
+
+# Don't `bundle install` which takes about 1.5 mins
+install: echo "skip bundle install"
 
 # Ensure we make ChefDK's Ruby the default
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,21 @@
-# Use Travis's cointainer based infrastructure
+language: ruby
 sudo: false
 
-language: ruby
-# Travis: Bundler that comes with Ruby 2.1.0 is too old (1.6.9)
-before_install: gem update bundler
-bundler_args: --without kitchen_vagrant
-rvm:
-- 2.1.0
+addons:
+  apt:
+    sources:
+      - chef-current-precise
+    packages:
+      - chefdk
+
+# Ensure we make ChefDK's Ruby the default
+before_script:
+  - eval "$(/opt/chefdk/bin/chef shell-init bash)"
 script:
-- bundle exec rake travis
+  - /opt/chefdk/embedded/bin/chef --version
+  - /opt/chefdk/embedded/bin/rubocop --version
+  - /opt/chefdk/embedded/bin/rubocop
+  - /opt/chefdk/embedded/bin/foodcritic --version
+  - /opt/chefdk/embedded/bin/foodcritic . --exclude spec
+  - /opt/chefdk/embedded/bin/rspec --version
+  - /opt/chefdk/embedded/bin/rspec


### PR DESCRIPTION
This should hopefully fix the issues we've seen with gem dependency failures when running builds in Travis CI. Since Travis only runs style-related checks we can rely directly on Chef DK's versions of those applications rather than running them with bundler.