### PR TITLE
Adds the ability to change the default category in the files added to the sumo sources folder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of sumologic-collector.
 
+## 1.2.18
+* Adds the ability to define the source categories for the default files created in the json source
+  folder.
+
 ## 1.2.17
 * Merged PR#85,86 : Add service retries attempts and delays, fixed online help doc link.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -94,6 +94,13 @@ when 'redhat', 'centos', 'scientific', 'fedora', 'suse', 'amazon', 'oracle', 'de
 
   # Collector Restart Command
   default['sumologic']['collectorRestartCmd'] = "#{default['sumologic']['installDir']}/collector restart"
+
+  # Syslog source category
+  default['sumologic']['syslog_cat'] = 'OS/Linux/System'
+
+  # Security source category
+  default['sumologic']['security_cat'] = 'OS/Linux/Security'
+
 when 'windows'
   # Install Path
   default['sumologic']['installDir'] = 'C:/sumo' # We'd like to set this to C:/Program Files/Sumo Logic Collector', but there are issues with the Program Files directory.

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ source_url 'https://github.com/SumoLogic/sumologic-collector-chef-cookbook' if r
 license 'Apache v2.0'
 description 'Installs/Configures sumologic-collector'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.17'
+version '1.2.18'
 attribute 'sumologic/credentials/bag_name',
   display_name: "Credentials bag name",
   type: "string",

--- a/recipes/sumojsondir.rb
+++ b/recipes/sumojsondir.rb
@@ -43,11 +43,17 @@ if !platform?('windows')
   template "#{node['sumologic']['sumo_json_path']}/localfile-system.json" do
     cookbook node['sumologic']['json_config_cookbook']
     source "localfile-system-dir.json.erb"
+    variables({
+      :category => node['sumologic']['syslog_cat']
+    })
   end
 
   template "#{node['sumologic']['sumo_json_path']}/localfile-security.json" do
     cookbook node['sumologic']['json_config_cookbook']
     source "localfile-security-dir.json.erb"
+    variables({
+      :category => node['sumologic']['security_cat']
+    })
   end
 
 # This is an example of another local file source, note the use of variables in this template

--- a/templates/default/localfile-security-dir.json.erb
+++ b/templates/default/localfile-security-dir.json.erb
@@ -9,7 +9,7 @@
             "useAutolineMatching": true,
             "forceTimeZone": false,
             "timeZone": "UTC",
-            "category": "OS/Linux/Security",
+            "category": "<%= @catergory %>",
 		<% case node["platform_family"] -%>
 		<%	when 'rhel'	%>
             "pathExpression":"/var/log/secure"

--- a/templates/default/localfile-security-dir.json.erb
+++ b/templates/default/localfile-security-dir.json.erb
@@ -9,7 +9,7 @@
             "useAutolineMatching": true,
             "forceTimeZone": false,
             "timeZone": "UTC",
-            "category": "<%= @catergory %>",
+            "category": "<%= @category %>",
 		<% case node["platform_family"] -%>
 		<%	when 'rhel'	%>
             "pathExpression":"/var/log/secure"

--- a/templates/default/localfile-system-dir.json.erb
+++ b/templates/default/localfile-system-dir.json.erb
@@ -9,7 +9,7 @@
             "useAutolineMatching": true,
             "forceTimeZone": false,
             "timeZone": "UTC",
-            "category": "OS/Linux/System",
+            "category": "<%= @category %>",
 			<% case node["platform_family"] -%>
 			<%	when 'rhel'	 %>
             "pathExpression":"/var/log/messages"


### PR DESCRIPTION
Adds the ability to manage the categories in the default files added to the sources folder when using the new local source mechanism.

This will allow orgs to manage where the syslog files for there orgs are categorised too.