### PR TITLE
Support pinning the chef vault version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -149,3 +149,5 @@ else
   # Collector Restart Command
   default['sumologic']['collectorRestartCmd'] = "#{default['sumologic']['installDir']}/collector restart"
 end
+
+default['sumologic']['chef_vault_version'] = '2.9.0'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -150,4 +150,4 @@ else
   default['sumologic']['collectorRestartCmd'] = "#{default['sumologic']['installDir']}/collector restart"
 end
 
-default['sumologic']['chef_vault_version'] = '2.9.0'
+default['sumologic']['chef_vault_version'] = nil

--- a/recipes/sumoconf.rb
+++ b/recipes/sumoconf.rb
@@ -32,6 +32,7 @@ credentials = {}
 
 chef_gem 'chef-vault' do
   compile_time true if respond_to?(:compile_time)
+  version node['sumologic']['chef_vault_version']
 end
 
 require 'chef-vault'

--- a/recipes/sumoconf.rb
+++ b/recipes/sumoconf.rb
@@ -32,7 +32,7 @@ credentials = {}
 
 chef_gem 'chef-vault' do
   compile_time true if respond_to?(:compile_time)
-  version node['sumologic']['chef_vault_version']
+  version node['sumologic']['chef_vault_version'] unless node['sumologic']['chef_vault_version'].nil?
 end
 
 require 'chef-vault'


### PR DESCRIPTION
Pin to the latest non 3.x release https://github.com/chef/chef-vault/blob/master/Changelog.md

Chef-vault release version 3.0.0 today which broke for us.
Namely, chef-vault now requires a version of Ruby >= 2.2.0 but we're running Ruby 2.1.x