### PR TITLE
Fix Foodcritic offenses

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,14 +8,6 @@ license 'Apache-2.0'
 description 'Installs/Configures sumologic-collector'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.2.20'
-attribute 'sumologic/credentials/bag_name',
-  display_name: "Credentials bag name",
-  type: "string",
-  required: "required"
-attribute 'sumologic/credentials/item_name',
-  display_name: "Credentials item name",
-  type: "string",
-  required: "required"
 chef_version '>= 11' if respond_to?(:chef_version)
 
 %w(

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer 'Sumo Logic'
 maintainer_email 'opensource@sumologic.com'
 issues_url 'https://github.com/SumoLogic/sumologic-collector-chef-cookbook/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/SumoLogic/sumologic-collector-chef-cookbook' if respond_to?(:source_url)
-license 'Apache v2.0'
+license 'Apache-2.0'
 description 'Installs/Configures sumologic-collector'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.2.20'

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,6 +16,7 @@ attribute 'sumologic/credentials/item_name',
   display_name: "Credentials item name",
   type: "string",
   required: "required"
+chef_version '>= 11' if respond_to?(:chef_version)
 
 %w(
   debian


### PR DESCRIPTION
Foodcritic has added new checks that are failing for this cookbook. See individual commits for brief explanations of each offence.