### PR TITLE
CHANGELOG and misc repo changes:

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+### Environment Information
+
+Please include the following:
+- version of cookbook:
+- version of chef:
+- operating system:
+- resources that are affected by issue:
+
+
+
+### Expected Behavior
+What should have happened?
+
+### Actual Behavior
+What actually happened?
+
+### Steps to Reproduce
+Please list the steps required to reproduce the issue
+
+
+### Important Factoids
+Are there anything atypical about the setup that we should know? For example everything goes through an HTTP/HTTPS proxy or I do not use rabbitmq.
+
+### References
+Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here? For example:
+- GH-1234

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Pull Request Checklist
+
+**Is this in reference to an existing issue?**
+
+#### General
+
+- [ ] Remove any versioning you did yourself if applicable
+
+- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/) with all new changes under `## [Unreleased]` and using a `### Added, Fixed, Changed, or Breaking Change` sub-header.
+
+- [ ] Update README with any necessary changes
+
+- [ ] RuboCop passes
+
+- [ ] Foodcritic passes
+
+- [ ] Existing tests pass
+
+
+#### Purpose
+
+#### Known Compatibility Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,74 +1,117 @@
 # CHANGELOG for sumologic-collector
+This project adheres to [Semantic Versioning](http://semver.org/).
 
-This file is used to list changes made in each version of sumologic-collector.
+This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-## 1.2.21
-* Merged PR#125, 130
+## [Unreleased]
+### Added
+- allow setting max_memory to control memory consumption : PR#128 (@dannenberg)
+- allow pinning version of chef-vault gem : PR#123 (@dhui)
 
-## 1.2.20
-* Undo PR#113
+### Changed
+- make travisci tests do what users expect them to : PR#134 (@majormoses)
+- updates for ubuntu 16.04, chef 13, fewer restart notifications, configure more java properties, misc kitchen platform updates : PR#122 (@RoboticCheese)
+- misc CHANGELOG updates : PR#137 (@majormoses)
 
-## 1.2.19
-* Merge PR#113
 
-## 1.2.18
-* Adds the ability to define the source categories for the default files created in the json source
+## [1.2.21] - 2017-06-12
+### Changed
+- appease CI, misc repo cleanup : Merged PR#125, 130 (@zl4bv, @majormoses)
+
+## [1.2.20] - 2017-04-26
+### Changed
+- revert buggy changes: Undo PR#113 (@duchatran)
+
+## [1.2.19] - 2017-03-29
+### Changed
+- prevent unnecessary collector restarts by only converge if changed  : Merge PR#113 (@dannenberg)
+
+## [1.2.18] - 2017-02-07
+### Added
+- Adds the ability to define the source categories for the default files created in the json source
   folder.
 
-## 1.2.17
-* Merged PR#85,86 : Add service retries attempts and delays, fixed online help doc link.
+## [1.2.17] - 2016-07-19
+### Added
+- Add service retries attempts and delays, fixed online help doc link : Merged PR#85,86 (@kquinsland, @meringu)
 
-## 1.2.15
-* Merged PR#76,77: Fix [issue 61](https://github.com/SumoLogic/sumologic-collector-chef-cookbook/issues/61) and Chef 11 incompatibility in metadata.rb
+## [1.2.15] - 2016-05-26
+### Fixed
+- Fix windows service collector name [issue 61](https://github.com/SumoLogic/sumologic-collector-chef-cookbook/issues/61): Merged PR#77 (@wenwolf)
+- Chef 11 compatibility improvements : Merged PR#76 (@elyobo)
 
-## 1.2.14
-* Merged PR#74: Add :disable  and :enable action to sumologic-collector, among other things.
+## [1.2.14]
+### Added
+- Add `:disable`  and `:enable` actions to sumologic-collector, among other things: Merged PR#74 (@KierranM)
 
-## 1.2.13
-* Merged PR#72: Use the net command to restart, start, and stop the
-  collector on windows
+## [1.2.13]
+### Fixed
+- Use the proper net command to restart, start, and stop the collector on windows: Merged PR#72 (@KierranM)
 
-## 1.2.12
-* Merged PR#71: Add a new sumologic_collector resource.
+## [1.2.12] - 2016-04-19
+### Added
+- Add a new `sumologic_collector` resource :  Merged PR#71  (@KierranM)
 
-## 1.2.11
-* Fixed issue 68 with PR#67
+## [1.2.11] - 2016-03-21
+### Fixed
+- fixing typo with `forceTimeZone` : PR#67 (@zl4bv)
 
-## 1.2.10
-* Added LWRP resources per PR#64
+## [1.2.10] - 2016-03-04
+### Added
+- Added LWRP resources for source config files :  Merged PR#64 (@zl4bv)
 
-## 1.2.9
-* Platform-family-specific install recipes
-* Windows 2008r2 and 2012r2 support and testing
+## [1.2.9] - 2016-02-25
+### Added
+- Platform-family-specific install recipes
+- Windows 2008r2 and 2012r2 support and testing
 
-## 1.2.8
-* Debian 8.1 support and testing
+## [1.2.8] - 2016-02-19
+### Added
+- Debian 8.1 support and testing
 
-## 1.2.7
-02/19/2016
-* Add action for debian 8.X
-* Add support for ChefVault
-* Ensure sumo-collector is running
+## [1.2.7] - 2016-02-19
+- Add action for debian 8.X
+- Add support for ChefVault
+- Ensure sumo-collector is running
 
-## 1.2.6
+## [1.2.6]
+### Added
+- Add support for restarting the collector on `Windows`
 
-* Add support for restarting the collector on `Windows`
+## [1.2.5] - 2015-10-08
+### Added
+- Add basic serverspec testing
 
-## 1.2.5
+## [1.2.0]
+### Added
+- Updated cookbook to support Access IDs and Keys
+- Updated cookbook to support Local Collector Management and JSON directory option.
 
-* Add basic serverspec
-
-## 1.2.00:
-
-* Updated cookbook to support Access IDs and Keys
-* Updated cookbook to support Local Collector Management and JSON directory option.
-
-## 0.1.0:
-
-* Initial release of sumologic-collector
+## [0.1.0] - 2015-09-02
+- Initial release of sumologic-collector
 
 
 - - -
 Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.
 
 The [Github Flavored Markdown page](http://github.github.com/github-flavored-markdown/) describes the differences between markdown on github and standard markdown.
+
+[Unreleased]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.21...HEAD
+[1.2.21]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.20...v1.2.21
+[1.2.20]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.19...v1.2.20
+[1.2.19]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.18...v1.2.19
+[1.2.18]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.17...v1.2.18
+[1.2.17]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.16...v1.2.17
+[1.2.16]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.15...v1.2.16
+[1.2.15]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.14...v1.2.15
+[1.2.14]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.13...v1.2.14
+[1.2.13]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.12...v1.2.13
+[1.2.12]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.11...v1.2.12
+[1.2.11]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.10...v1.2.11
+[1.2.10]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.9...v1.2.10
+[1.2.9]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.8...v1.2.9
+[1.2.8]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.7...v1.2.8
+[1.2.7]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.6...v1.2.7
+[1.2.6]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.5...v1.2.6
+[1.2.5]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.4...v1.2.5
+[1.2.4]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/compare/v1.2.3...v1.2.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+Contributing to cookbook-elasticsearch
+======================================
+
+### Workflow for contributing
+
+1. Create a branch directly in this repo or a fork (if you don't have push access). Please name branches within this repository `<fix type>/<description>`. For example, something like feature/install_from_deb.
+
+1. Create an issue or open a PR. If you aren't sure your PR will solve the issue, or may be controversial, we commend opening an issue separately and linking to it in your PR, so that if the PR is not accepted, the issue will remain and be tracked.
+
+1.  Close (and reference) issues by the `closes #XXX` or `fixes #XXX` notation in the commit message. Please use a descriptive, useful commit message that could be used to understand why a particular change was made.
+
+1. Keep pushing commits to the initial branch, `--amend`-ing if necessary. Please don't mix fixing unrelated issues in a single branch.
+
+1. Create a changelog entry as per [Keep A Changelog](http://keepachangelog.com/). You should only be putting new stuff under `## [Unreleased]` and should not concern yourself with bumping the version and dates as this will be done when releasing changes. When you need to have a change that will break things it needs to be called out with a `### Breaking Changes` as opposed to a more common header such as `### Added, ### Fixed, ### Changed`. This helps maintainers evaluate what the appropriate version bump should be as there could be changes that are not immediately released.
+
+1. When everything is ready for merge, clean up the branch (rebase with master to synchronize, squash, edit commits, etc) to prepare for it to be merged. Unless you have meaningful history it should be a single commit. Prefer a rebase to a merge for brining in changes that have been committed to upstream master.
+
+### Merging contributions
+
+1. After reviewing commits for documentation, passing CI tests, and good descriptive commit messages, merge it with either "squash and merge" or "rebase and merge" do not use the
+"merge pull request" as it does not do a fast forward first.
+
+
+### Releasing
+
+1. Create/update the changelog entries and evaluate the type of release.
+1. create a git release with something like hub, example: `hub release create vMajor.Minor.patch`

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'buff-extensions', '~> 2.0'
-gem 'chef'
+gem 'chef', '~> 12.0'
+gem 'chef-zero', '~> 5.3'
 gem 'chefspec'
 gem 'kitchen-inspec'
 gem 'kitchen-vagrant'

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ installer and on Windows uses the exe installer. Here are the steps it follows:
 3. Runs installer
 4. Starts collector and registers with the Sumo Logic service
 
-For collector update, the existing collector must have been switched to use Local Configuration Mangement - see the instructions to 
+For collector update, the existing collector must have been switched to use Local Configuration Mangement - see the instructions to
 configure [New Collectors](https://help.sumologic.com/Send_Data/Local_Configuration_File_Management/Local_File_Configuration_Management_for_New_Collectors_and_Sources)
 or [Existing Collectors](https://help.sumologic.com/Send_Data/Local_Configuration_File_Management/Local_Configuration_File_Management_for_Existing_Collectors_and_Sources)
 for more details. The steps the cookbook follows:
@@ -29,9 +29,9 @@ Edit `sumo.json` (or the json files under the json folder) to add/edit/remove so
 Note
 ------
 Starting from 19.107, there are 2 major extensions to SumoLogic collectors:
-* You can configure a collector's parameters from a set of json files under a common folder. Each of the json file will represent a source on that collector. Updates made to a json file will then be reflected on its corresponding source. Note that the format of this kind of file is **slightly different** from that of the traditional single json file (sumo.json) and they are **not** compatible. You also need to use the parameter `syncSources` instead of `sources` inside `sumo.conf`. 
+* You can configure a collector's parameters from a set of json files under a common folder. Each of the json file will represent a source on that collector. Updates made to a json file will then be reflected on its corresponding source. Note that the format of this kind of file is **slightly different** from that of the traditional single json file (sumo.json) and they are **not** compatible. You also need to use the parameter `syncSources` instead of `sources` inside `sumo.conf`.
 See more details [here](https://help.sumologic.com/Send_Data/Installed_Collectors/sumo.conf).
-* You can change a collector's existing parameters through local configuration json file(s) continuously. Before this, using collector API was the only option. 
+* You can change a collector's existing parameters through local configuration json file(s) continuously. Before this, using collector API was the only option.
 More information about this is [here](https://help.sumologic.com/Send_Data/Local_Configuration_File_Management)
 
 Installation
@@ -543,9 +543,7 @@ end
 
 Contributing
 ------------
-This cookbook is meant to help customers use Chef to install Sumo Logic
-collectors, so please feel to fork this repository, and make whatever changes
-you need for your environment.
+Please see CONTRIBUTING.md for guidelines
 
 
 License and Authors


### PR DESCRIPTION
- clairfy versioning of project to use semver2
- Switch CHANGELOG format to follow good practices from http://keepachangelog.com
- lock chef gems to chef 12 in preparation for dropping chef 11 support.
- added issue and pr github templates