### PR TITLE
allow overriding the init subsystem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,7 @@ This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keep
 
 ## [Unreleased]
 ### Added
-- TBD
-
-### Changed
-- TBD
+- the ability to use `node['sumologic']['init_style']` to specify an override for an init subsystem while keeping the same defaults of delegating that to ohai detection.
 
 ## [1.2.22] - 2017-08-15
 ### Added

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -154,3 +154,14 @@ else
 end
 
 default['sumologic']['chef_vault_version'] = nil
+
+# if left nil it will defer to ohai to determine, you can
+# change the behavior to use a specific init style as long
+# as the collector and chef supports it. Consult the chef
+# documentation here: https://docs.chef.io/resource_service.html
+# for a list of acceptable options. Some examples:
+# `Chef::Provider::Service::Systemd`, `Chef::Provider::Service::Upstart`,
+# `Chef::Provider::Service::Init::Debian`, etc. Here is
+# the source of trusth on supported init subsystemds:
+# https://github.com/chef/chef/tree/v13.4.19/lib/chef/provider/service
+default['sumologic']['init_style'] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -44,10 +44,12 @@ if File.exist? node['sumologic']['installDir']
   when 'rhel', 'amazon', 'linux', 'debian'
     service 'collector' do
       action :start
+      provider node['sumologic']['init_style'] unless node['sumologic']['init_style'].nil?
     end
   else
     service 'sumo-collector' do
       action :start
+      provider node['sumologic']['init_style'] unless node['sumologic']['init_style'].nil?
     end
   end
 


### PR DESCRIPTION
relates to #141

We now allow using `node['sumologic']['init_style']` with any valid chef provider. Default is `nil` and will defer to ohai unless overridden.

Note: it does not attempt an validation that you chose a valid provider.

Signed-off-by: Ben Abrams <me@benabrams.it>


#### General

- [ ] Remove any versioning you did yourself if applicable

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/) with all new changes under `## [Unreleased]` and using a `### Added, Fixed, Changed, or Breaking Change` sub-header.

- [ ] Update README with any necessary changes

- [ ] RuboCop passes

- [ ] Foodcritic passes

- [ ] Existing tests pass


#### Purpose
Allow overwriting the init subsystem used when starting the collector.
#### Known Compatibility Issues
If you choose an init subsystem that the collector does not support you will need to write your init script yourself. There are a limited number of providers, at the time of writing this: https://github.com/chef/chef/tree/v13.4.19/lib/chef/provider/service is a list of them.