### PR TITLE
add support for `sumo_service` to override the init system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-### Added
-TBD
 
-### Changed
-TBD
+### Added
+- when using the lwrps it calls `sumo_service` which attempts to use systemd if present. We should allow overriding this behavior with the same attribute as was added in [PR#145](https://github.com/SumoLogic/sumologic-collector-chef-cookbook/pull/145) to change the behavior. If the attribute is unset it uses the existing logic to determine the appropriate init subsystem making this backwards compatibile. (@majormoses)
 
 ## [1.2.23] - 2017-10-12
 ### Added

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -160,13 +160,15 @@ def wait_if_initial_startup
   end
 end
 
-def sumo_service(action = :nothing)
+def sumo_service(action = :nothing) # rubocop:disable Metrics/AbcSize
   service 'sumo-collector' do
     service_name 'collector' unless node['platform_family'] == 'windows'
     retries new_resource.service_retries
     retry_delay new_resource.service_retry_delay
     supports status: true, restart: true
-    if Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)
+    if !node['sumologic']['init_style'].nil?
+      provider node['sumologic']['init_style']
+    elsif Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)
       provider Chef::Provider::Service::Systemd
     end
     action action


### PR DESCRIPTION
## Pull Request Checklist

#141 , #145 

#### General

- [x] Remove any versioning you did yourself if applicable

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/) with all new changes under `## [Unreleased]` and using a `### Added, Fixed, Changed, or Breaking Change` sub-header.

- [ ] Update README with any necessary changes

- [ ] RuboCop passes

- [ ] Foodcritic passes

- [ ] Existing tests pass


#### Purpose
To allow in the lwrps to use `node['sumologic']['init_style']` to override the behavior of assuming systemd if detected, if it is not provided the existing logic will be executed.
#### Known Compatibility Issues
This was made to be backwards compatible.