### PR TITLE
Fixed rubocop error

### DIFF
--- a/libraries/provider_source.rb
+++ b/libraries/provider_source.rb
@@ -31,7 +31,7 @@ class Chef
             rights new_resource.rights
           end
           # please fix me!
-          sensitive(/password/i === config_json) # rubocop:disable Style/CaseEquality
+          sensitive(config_json === /password/i) # rubocop:disable Style/CaseEquality
         end
       end
 


### PR DESCRIPTION
Offenses:

libraries/provider_source.rb:34:21: C: Reverse the order of the operands /password/i === config_json.
          sensitive(/password/i === config_json) # rubocop:disable Style/CaseEquality
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^

Signed-off-by: JJ Asghar <jj@chef.io>