### PR TITLE
Leave the service disabled after the collector resource's :install action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- leave the service disabled after the collector resource's :install action (@RoboticCheese)
 
 ## [1.3.0] - 2018-04-19
 ### Added

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -22,6 +22,7 @@ action :install do
     new_resource.sumo_access_key('0000000000000000000000000')
     installer_cmd = [installer_bin, installer_opts].join(' ').strip
     run_installer installer_cmd
+    sumo_service :disable
   end
 end
 

--- a/test/integration/default-resource-install/serverspec/default_spec.rb
+++ b/test/integration/default-resource-install/serverspec/default_spec.rb
@@ -13,3 +13,10 @@ describe file("#{sumo_dir}/config/user.properties") do
   its(:content) { is_expected.to match(/accessid=00000000000/) }
   its(:content) { is_expected.to match(/accesskey=0000000000000000000000000/) }
 end
+
+svc = os[:family] == 'windows' ? 'sumo-collector' : 'collector'
+
+describe service(svc) do
+  it { should_not be_running }
+  it { should_not be_enabled }
+end


### PR DESCRIPTION

## Pull Request Checklist

**Is this in reference to an existing issue?**

No.

#### General

- [x] Remove any versioning you did yourself if applicable

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/) with all new changes under `## [Unreleased]` and using a `### Added, Fixed, Changed, or Breaking Change` sub-header.

- [x] Update README with any necessary changes

- [x] RuboCop passes

- [x] Foodcritic passes

- [x] Existing tests pass

#### Purpose

The installer script, even if it's run with `-VskipRegistration=true`, enables
the service. This means the collector resource's `:install` action leaves
behind an unconfigured collector that will nonetheless try (and fail) to start
at boot time.

I can see the argument that this is the install script's default behavior, so
this is the state it should be left in. But it was a small enough change I
wanted to submit it and see what folks think.