### PR TITLE
Fields support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keep
 ## [Unreleased]
 ### Added 
 - Added securefiles boolean flag in installer to enable or disable enhanced file security.
+- added fields support to user.properties
 
 ## [1.4.0] - 2018-06-26
 ### Added

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ for more information about these attributes.
 | `runas_username` | `String` | Which user the daemon will run as | `nil` | `false` | `:install_and_configure`, `:install` |
 | `winrunas_password` | `String` | On Windows, the password for the user the service will run as | `nil` | `false` | `:install_and_configure`, `:install` |
 | `skip_registration` | `Boolean` | When `true` the collector will not register upon installation | `false` | `nil` | `:install_and_configure` |
+| `fields` | `Hash` | Sets the fields property in user.properties used by ingest budgets and other future features | `nil` | `false` | `:install_and_configure`, `:configure` |
 
 sumologic_collector_installer
 ---------

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -42,6 +42,7 @@ attribute :time_zone, kind_of: String, default: nil
 attribute :target_cpu, kind_of: Integer, default: nil
 attribute :wrapper_java_initmemory, kind_of: Integer, default: nil
 attribute :wrapper_java_maxmemory, kind_of: Integer, default: nil
+attribute :fields, kind_of: Hash, default: nil
 
 # Misc
 attribute :installed, kind_of: [TrueClass, FalseClass], default: false

--- a/templates/default/user.properties.erb
+++ b/templates/default/user.properties.erb
@@ -36,4 +36,4 @@ name=<%= @resource.collector_name %>
 <%= "targetCPU=#{@resource.target_cpu}" unless @resource.target_cpu.nil? %>
 <%= "wrapper.java.initmemory=#{@resource.wrapper_java_initmemory}" unless @resource.wrapper_java_initmemory.nil? %>
 <%= "wrapper.java.maxmemory=#{@resource.wrapper_java_maxmemory}" unless @resource.wrapper_java_maxmemory.nil? %>
-<%= "fields=#{@resource.fields}" unless @resource.fields.nil? %>
+<%= "fields=#{@resource.fields.map { |key, val| "#{key}=#{val}"}.join(",")}" unless @resource.fields.nil? %>

--- a/templates/default/user.properties.erb
+++ b/templates/default/user.properties.erb
@@ -36,3 +36,4 @@ name=<%= @resource.collector_name %>
 <%= "targetCPU=#{@resource.target_cpu}" unless @resource.target_cpu.nil? %>
 <%= "wrapper.java.initmemory=#{@resource.wrapper_java_initmemory}" unless @resource.wrapper_java_initmemory.nil? %>
 <%= "wrapper.java.maxmemory=#{@resource.wrapper_java_maxmemory}" unless @resource.wrapper_java_maxmemory.nil? %>
+<%= "fields=#{@resource.fields}" unless @resource.fields.nil? %>


### PR DESCRIPTION
## Pull Request Checklist

fixes #166 

#### General

- [x] Remove any versioning you did yourself if applicable
y

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/) with all new changes under `## [Unreleased]` and using a `### Added, Fixed, Changed, or Breaking Change` sub-header.
added to unreleased Added header

- [x] Update README with any necessary changes
added fields

- [x] RuboCop passes
it doesn't but looks like it didn't before, nothing new from my changes

- [x] Foodcritic passes
once again probably no new problems on top of what's there
............x........xx...........................
FC113: Resource declares deprecated use_inline_resources: ./libraries/provider_source.rb:11
FC113: Resource declares deprecated use_inline_resources: ./providers/default.rb:3
FC113: Resource declares deprecated use_inline_resources: ./providers/installer.rb:3

- [x] Existing tests pass
tried running this but the vagrant VM crashes out. I don't think this is related to my changes.
```
Installing Cookbook Gems:
       Compiling Cookbooks...
       [2019-07-16T02:40:45+00:00] WARN: ***************** Creating a fake Data Bag with real Sumo key
       Recipe: sumologic-collector::sumoconf
         * chef_gem[chef-vault] action install (up to date)
       [2019-07-16T02:40:46+00:00] ERROR: #<FFI_Yajl::ParseError: parse error: invalid object key (must be a string)
          qkZ9ohrk0YZOmA1KtNlkoUoQ9v", } 
                     (right here) ------^
       >
       /opt/chef/embedded/lib/ruby/gems/2.6.0/gems/ffi-yajl-2.3.1/lib/ffi_yajl/parser.rb:87:in `do_yajl_parse'
       /opt/chef/embedded/lib/ruby/gems/2.6.0/gems/ffi-yajl-2.3.1/lib/ffi_yajl/parser.rb:87:in `parse'
```

#### Purpose
Make it possible to specify fields property in user.properties using the chef cookbook.

#### Known Compatibility Issues
none