### PR TITLE
fixes #168 to support download source overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keep
 ### Added 
 - Added securefiles boolean flag in installer to enable or disable enhanced file security.
 
+### Fixed
+- Set default provider installer_source to use attributes so the URL can be overridden if necessary.
+
 ## [1.4.0] - 2018-06-26
 ### Added
 - Added `cutoffTimestamp` and `cutoffRelativeTime` properties.

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -120,13 +120,9 @@ def installer_bin
 end
 
 def installer_source
-  case node['platform_family']
-  when 'windows'
-    node['kernel']['machine'] =~ /^x86_64$/ ? 'https://collectors.sumologic.com/rest/download/win64' : 'https://collectors.sumologic.com/rest/download/windows'
-  else
-    url = 'https://collectors.sumologic.com/rest/download/linux'
-    "#{url}/#{node['kernel']['machine'] =~ /^i[36']86$/ ? '32' : '64'}"
-  end
+  # the attributes file already has logic in it to evaluate the platform and architecture so rather than re-evaluating
+  # we can just directly reference the downloadUrl attribute and get the correct URL
+  node['sumologic']['downloadUrl']
 end
 
 def download_installer


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
yes
#### General

- [ ] Remove any versioning you did yourself if applicable

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/) with all new changes under `## [Unreleased]` and using a `### Added, Fixed, Changed, or Breaking Change` sub-header.

- [ ] Update README with any necessary changes

- [ ] RuboCop passes

- [ ] Foodcritic passes

- [ ] Existing tests pass


#### Purpose
In the event of the current installer having problems or someone wanting to install an older version of a collector there is currently no way to pass an override of the source.

#### Known Compatibility Issues
