### PR TITLE
Migrate deprecated script/action disabling flags

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -35,8 +35,8 @@ attribute :sources, kind_of: String, default: nil
 attribute :sync_sources, kind_of: String, default: nil
 attribute :ephemeral, kind_of: [TrueClass, FalseClass], default: false
 attribute :clobber, kind_of: [TrueClass, FalseClass], default: false
-attribute :disable_script_source, kind_of: [TrueClass, FalseClass], default: false
-attribute :disable_action_source, kind_of: [TrueClass, FalseClass], default: false
+attribute :enable_script_source, kind_of: [TrueClass, FalseClass], default: false
+attribute :enable_action_source, kind_of: [TrueClass, FalseClass], default: false
 attribute :disable_upgrade, kind_of: [TrueClass, FalseClass], default: false
 attribute :time_zone, kind_of: String, default: nil
 attribute :target_cpu, kind_of: Integer, default: nil

--- a/templates/default/user.properties.erb
+++ b/templates/default/user.properties.erb
@@ -29,8 +29,8 @@ name=<%= @resource.collector_name %>
 <%= "syncSources=#{@resource.sync_sources}" unless @resource.sync_sources.nil? %>
 <%= "ephemeral=#{@resource.ephemeral}" unless @resource.ephemeral.nil? %>
 <%= "clobber=#{@resource.clobber}" unless @resource.clobber.nil? %>
-<%= "disableScriptSource=#{@resource.disable_script_source}" unless @resource.disable_script_source.nil? %>
-<%= "disableActionSource=#{@resource.disable_action_source}" unless @resource.disable_action_source.nil? %>
+<%= "enableScriptSource=#{@resource.enable_script_source}" unless @resource.disable_script_source.nil? %>
+<%= "enableActionSource=#{@resource.enable_action_source}" unless @resource.disable_action_source.nil? %>
 <%= "disableUpgrade=#{@resource.disable_upgrade}" unless @resource.disable_upgrade.nil? %>
 <%= "timeZone=#{@resource.time_zone}" unless @resource.time_zone.nil? %>
 <%= "targetCPU=#{@resource.target_cpu}" unless @resource.target_cpu.nil? %>


### PR DESCRIPTION
## Pull Request Checklist
**Is this in reference to an existing issue?** No
#### General
- [x] Remove any versioning you did yourself if applicable
- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/) with all new changes under `## [Unreleased]` and using a `### Added, Fixed, Changed, or Breaking Change` sub-header.
- [ ] Update README with any necessary changes
- [ ] RuboCop passes
- [ ] Foodcritic passes
- [x] Existing tests pass
#### Purpose
See https://help.sumologic.com/03Send-Data/Installed-Collectors/05Reference-Information-for-Collector-Installation/06user.properties - the disableScript/ActionSource flags have been migrated to enableScript/ActionSource as of Collector version 19.245-4 . I'll update the documentation and changelog once this is approved.
#### Known Compatibility Issues
For collector version 19.245+.