### PR TITLE
Migrate deprecated script/action disabling flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keep
 - Added securefiles boolean flag in installer to enable or disable enhanced file security.
 - added fields support to user.properties
 
+## Changed
+- Deprecated flags disableScript/ActionSource removed.
+- Script / Action Sources are disabled by default.
+
 ## [1.4.0] - 2018-06-26
 ### Added
 - Added `cutoffTimestamp` and `cutoffRelativeTime` properties.

--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ for more information about these attributes.
 | `sync_sources` | `String` | Sets the JSON file describing sources to configure on registration, which will be continuously monitored and synchronized with the Collector's configuration | `nil` | `false` | `:install_and_configure`, `:configure` |
 | `ephemeral` | `Boolean` | When `true`, the Collector will be deleted after goes offline for a certain period of time | `false` | `false` | `:install_and_configure`, `:configure` |
 | `clobber` | `Boolean` | When `true`, if there is any existing Collector with the same name, that Collector will be deleted | `false` | `false` | `:install_and_configure`, `:configure` |
-| `disable_script_source` | `Boolean` | If your organization's internal policies restrict the use of scripts, you can disable the creation of script-based Script Sources. When this parameter is passed, this option is removed from the Sumo Logic Web Application, and Script Source cannot be configured | `false` | `false` | `:install_and_configure`, `:configure` |
-| `disable_action_source` | `Boolean` | If your organization's internal policies restrict the use of script actions, you can disable the creation of script-based action sources. When this parameter is passed, action sources will not execute on this collector. | `false` | `false` | `:install_and_configure`, `:configure` |
 | `disable_upgrade` | `Boolean` | If true, the collector rejects upgrade requests from Sumo. | `false` | `false` | `:install_and_configure`, `:configure` |
+| `enable_script_source` | `Boolean` | Script Sources are disabled by default. You can enable them by setting this parameter to true. | `false` | `false` | `:install_and_configure`, `:configure` |
+| `enable_action_source` | `Boolean` | Script Action Sources are disabled by default. You can enable them by setting this parameter to true. | `false` | `false` | `:install_and_configure`, `:configure` |
 | `time_zone` | `String` | The default time zone for sources on this collector | `nil` | `false` | `:install_and_configure`, `:configure` |
 | `target_cpu` | `Integer` | Target to which to limit the CPU usage of this collector | `nil` | `false` | `:install_and_configure`, `:configure` |
 | `wrapper_java_initmemory` | `Integer` | Override the initial Java heap size | `nil` | `false` | `:configure` |

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -35,8 +35,8 @@ attribute :sources, kind_of: String, default: nil
 attribute :sync_sources, kind_of: String, default: nil
 attribute :ephemeral, kind_of: [TrueClass, FalseClass], default: false
 attribute :clobber, kind_of: [TrueClass, FalseClass], default: false
-attribute :disable_script_source, kind_of: [TrueClass, FalseClass], default: false
-attribute :disable_action_source, kind_of: [TrueClass, FalseClass], default: false
+attribute :enable_script_source, kind_of: [TrueClass, FalseClass], default: false
+attribute :enable_action_source, kind_of: [TrueClass, FalseClass], default: false
 attribute :disable_upgrade, kind_of: [TrueClass, FalseClass], default: false
 attribute :time_zone, kind_of: String, default: nil
 attribute :target_cpu, kind_of: Integer, default: nil

--- a/templates/default/user.properties.erb
+++ b/templates/default/user.properties.erb
@@ -29,8 +29,8 @@ name=<%= @resource.collector_name %>
 <%= "syncSources=#{@resource.sync_sources}" unless @resource.sync_sources.nil? %>
 <%= "ephemeral=#{@resource.ephemeral}" unless @resource.ephemeral.nil? %>
 <%= "clobber=#{@resource.clobber}" unless @resource.clobber.nil? %>
-<%= "disableScriptSource=#{@resource.disable_script_source}" unless @resource.disable_script_source.nil? %>
-<%= "disableActionSource=#{@resource.disable_action_source}" unless @resource.disable_action_source.nil? %>
+<%= "enableScriptSource=#{@resource.enable_script_source}" unless @resource.disable_script_source.nil? %>
+<%= "enableActionSource=#{@resource.enable_action_source}" unless @resource.disable_action_source.nil? %>
 <%= "disableUpgrade=#{@resource.disable_upgrade}" unless @resource.disable_upgrade.nil? %>
 <%= "timeZone=#{@resource.time_zone}" unless @resource.time_zone.nil? %>
 <%= "targetCPU=#{@resource.target_cpu}" unless @resource.target_cpu.nil? %>


### PR DESCRIPTION
## Pull Request Checklist
**Is this in reference to an existing issue?** No
#### General
- [x] Remove any versioning you did yourself if applicable
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/) with all new changes under `## [Unreleased]` and using a `### Added, Fixed, Changed, or Breaking Change` sub-header.
- [x] Update README with any necessary changes
- [ ] RuboCop passes
- [ ] Foodcritic passes
- [x] Existing tests pass
#### Purpose
See https://help.sumologic.com/03Send-Data/Installed-Collectors/05Reference-Information-for-Collector-Installation/06user.properties - the disableScript/ActionSource flags have been migrated to enableScript/ActionSource as of Collector version 19.245-4 .
#### Known Compatibility Issues
For collector version 19.245+.