### PR TITLE
Support chef 16 by setting `provides` on custom resources.  Fixes #178.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 ## [Unreleased]
+### Changed
+- Chef 16 support. HWRP-style resources now require either the use of `resource_name` or `provides`
 
 ## [1.5.0] - 2021-01-06
 ### Added 

--- a/libraries/resource_docker_source.rb
+++ b/libraries/resource_docker_source.rb
@@ -6,6 +6,8 @@ require_relative 'resource_source'
 class Chef
   class Resource
     class SumoSourceDocker < Chef::Resource::SumoSource
+      provides :sumo_source_docker if respond_to?(:provides)
+
       attribute :source_type, kind_of: Symbol, required: true, equal_to: %i[docker_stats docker_log]
       attribute :uri, kind_of: String, required: true
       attribute :specified_containers, kind_of: Array

--- a/libraries/resource_graphite_metrics_source.rb
+++ b/libraries/resource_graphite_metrics_source.rb
@@ -6,6 +6,8 @@ require_relative 'resource_source'
 class Chef
   class Resource
     class SumoSourceGraphiteMetrics < Chef::Resource::SumoSource
+      provides :sumo_source_graphite_metrics if respond_to?(:provides)
+
       attribute :source_type, kind_of: Symbol, default: :graphite, equal_to: [:graphite]
       attribute :protocol, kind_of: String, default: 'TCP'
       attribute :port, kind_of: Integer, default: 2003

--- a/libraries/resource_local_file_source.rb
+++ b/libraries/resource_local_file_source.rb
@@ -6,6 +6,8 @@ require_relative 'resource_source'
 class Chef
   class Resource
     class SumoSourceLocalFile < Chef::Resource::SumoSource
+      provides :sumo_source_local_file if respond_to?(:provides)
+
       attribute :source_type, kind_of: Symbol, default: :local_file, equal_to: [:local_file]
       attribute :path_expression, kind_of: String, required: true
       attribute :blacklist, kind_of: Array

--- a/libraries/resource_local_win_event_log_source.rb
+++ b/libraries/resource_local_win_event_log_source.rb
@@ -6,6 +6,8 @@ require_relative 'resource_source'
 class Chef
   class Resource
     class SumoSourceLocalWindowsEventLog < Chef::Resource::SumoSource
+      provides :sumo_source_local_windows_event_log if respond_to?(:provides)
+
       attribute :source_type, kind_of: Symbol, default: :local_windows_event_log, equal_to: [:local_windows_event_log]
       attribute :log_names, kind_of: Array, required: true
     end

--- a/libraries/resource_remote_file_source.rb
+++ b/libraries/resource_remote_file_source.rb
@@ -6,6 +6,8 @@ require_relative 'resource_source'
 class Chef
   class Resource
     class SumoSourceRemoteFile < Chef::Resource::SumoSource
+      provides :sumo_source_remote_file if respond_to?(:provides)
+
       attribute :source_type, kind_of: Symbol, default: :remote_file, equal_to: [:remote_file]
       attribute :remote_hosts, kind_of: Array, required: true
       attribute :remote_port, kind_of: Integer, required: true

--- a/libraries/resource_remote_win_event_log_source.rb
+++ b/libraries/resource_remote_win_event_log_source.rb
@@ -6,6 +6,8 @@ require_relative 'resource_source'
 class Chef
   class Resource
     class SumoSourceRemoteWindowsEventLog < Chef::Resource::SumoSource
+      provides :sumo_source_remote_windows_event_log if respond_to?(:provides)
+
       attribute :source_type, kind_of: Symbol, default: :remote_windows_event_log, equal_to: [:remote_windows_event_log]
       attribute :domain, kind_of: String, required: true
       attribute :username, kind_of: String, required: true

--- a/libraries/resource_script_source.rb
+++ b/libraries/resource_script_source.rb
@@ -6,6 +6,8 @@ require_relative 'resource_source'
 class Chef
   class Resource
     class SumoSourceScript < Chef::Resource::SumoSource
+      provides :sumo_source_script if respond_to?(:provides)
+
       attribute :source_type, kind_of: Symbol, default: :script, equal_to: [:script]
       attribute :commands, kind_of: Array, required: true
       attribute :file, kind_of: String

--- a/libraries/resource_source.rb
+++ b/libraries/resource_source.rb
@@ -6,6 +6,8 @@ require 'chef/platform/query_helpers'
 class Chef
   class Resource
     class SumoSource < Chef::Resource::LWRPBase
+      provides :sumo_source if respond_to?(:provides)
+
       default_action :create
 
       actions :create

--- a/libraries/resource_syslog_source.rb
+++ b/libraries/resource_syslog_source.rb
@@ -6,6 +6,8 @@ require_relative 'resource_source'
 class Chef
   class Resource
     class SumoSourceSyslog < Chef::Resource::SumoSource
+      provides :sumo_source_syslog if respond_to?(:provides)
+
       attribute :source_type, kind_of: Symbol, default: :syslog, equal_to: [:syslog]
       attribute :protocol, kind_of: String, default: 'UDP'
       attribute :port, kind_of: Integer, default: 514


### PR DESCRIPTION
This change maintains backwards compatibility with previous chef client versions.

https://github.com/chef/chef/blob/master/RELEASE_NOTES.md#whats-new-in-16244

Signed-off-by: Eric Millbrandt <emillbrandt@brightcove.com>

## Pull Request Checklist

Fixes #178.

#### General

- [ ] Remove any versioning you did yourself if applicable

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/) with all new changes under `## [Unreleased]` and using a `### Added, Fixed, Changed, or Breaking Change` sub-header.

- [ ] Update README with any necessary changes

- [ ] RuboCop passes

- [ ] Foodcritic passes

- [ ] Existing tests pass


#### Purpose

#### Known Compatibility Issues
