### PR TITLE
allow specifying a `fields` Hash to tag collector sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-### Added 
+### Added
 - Added securefiles boolean flag in installer to enable or disable enhanced file security.
 - added fields support to user.properties
+- added `fields` support to sources (@majormoses)
 
 ### Changed
 - Deprecated flags disableScript/ActionSource removed.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ for more details. The steps the cookbook follows:
 
 1. Verify that the collector folder exists.
 2. (Optional) Recreate `sumo.conf` and `sumo.json` (or the json files under the json folder).
-3. Restart the collector for the changes to take effect.   
+3. Restart the collector for the changes to take effect.
 
 The collector Requires outbound access to https://collectors.sumologic.com.
 Edit `sumo.json` (or the json files under the json folder) to add/edit/remove sources.  After installation you can
@@ -357,6 +357,10 @@ listed above.
 sumo_source_local_file 'local_file' do
   source_json_directory node['sumologic']['sumo_json_path']
   path_expression '/tmp/example'
+  fields {
+    _siemforward: true,
+    parser: '/MY_EXAMPLE_PARSER'
+  }
 end
 ```
 

--- a/libraries/provider_source.rb
+++ b/libraries/provider_source.rb
@@ -47,6 +47,7 @@ class Chef
         hash['source']['name'] = new_resource.name
         hash['source']['description'] = new_resource.description unless new_resource.description.nil?
         hash['source']['category'] = new_resource.category unless new_resource.category.nil?
+        hash['source']['fields'] = new_resource.fields unless new_resource.fields.nil?
         hash['source']['hostName'] = new_resource.host_name unless new_resource.host_name.nil?
         hash['source']['timeZone'] = new_resource.time_zone unless new_resource.time_zone.nil?
         hash['source']['automaticDateParsing'] = new_resource.automatic_date_parsing unless new_resource.automatic_date_parsing.nil?

--- a/libraries/resource_source.rb
+++ b/libraries/resource_source.rb
@@ -44,6 +44,7 @@ class Chef
       attribute :alive, kind_of: [TrueClass, FalseClass]
       attribute :cuttoff_timestamp, kind_of: String
       attribute :cuttoff_relative_time, kind_of: String
+      attribute :fields, kind_of: [Hash, NilClass], default: nil
     end
   end
 end


### PR DESCRIPTION
## Pull Request Checklist

This is similar to #167 but in the context of a source rather than a collector.

#### General

- [x] Remove any versioning you did yourself if applicable

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/) with all new changes under `## [Unreleased]` and using a `### Added, Fixed, Changed, or Breaking Change` sub-header.

- [x] Update README with any necessary changes

- [ ] RuboCop passes

- [ ] Foodcritic passes

- [ ] Existing tests pass


#### Purpose

Allow specifying `fields` on sources per: https://help.sumologic.com/03Send-Data/Sources/03Use-JSON-to-Configure-Sources

#### Known Compatibility Issues
