### PR TITLE
allow specifying a `fields` Hash to tag collector sources

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,11 +28,11 @@ MethodLength:
   CountComments: false  # count full line comments?
   Max: 40
 
-# Raise allowed CyclomaticComplexity & Perceivedto 10.
+# Raise allowed CyclomaticComplexity & Perceived from 10.
 CyclomaticComplexity:
-  Max: 15
+  Max: 20
 Metrics/PerceivedComplexity:
-  Max: 15
+  Max: 20
 
 # Don't force a word array unless 5 elements
 WordArray:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keep
 
 ## [Unreleased changes]
 
+### Added
+- added `fields` support to sources (@majormoses)
 ## [1.6.1] - 2021-08-27
 ### Changed
 - fix install_and_configure behavior [#185]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keep
 
 ### Added
 - added `fields` support to sources (@majormoses)
+
 ## [1.6.1] - 2021-08-27
 ### Changed
 - fix install_and_configure behavior [#185]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ for more details. The steps the cookbook follows:
 
 1. Verify that the collector folder exists.
 2. (Optional) Recreate `sumo.conf` and `sumo.json` (or the json files under the json folder).
-3. Restart the collector for the changes to take effect.   
+3. Restart the collector for the changes to take effect.
 
 The collector Requires outbound access to https://collectors.sumologic.com.
 Edit `sumo.json` (or the json files under the json folder) to add/edit/remove sources.  After installation you can
@@ -357,6 +357,10 @@ listed above.
 sumo_source_local_file 'local_file' do
   source_json_directory node['sumologic']['sumo_json_path']
   path_expression '/tmp/example'
+  fields {
+    _siemforward: true,
+    parser: '/MY_EXAMPLE_PARSER'
+  }
 end
 ```
 

--- a/libraries/provider_source.rb
+++ b/libraries/provider_source.rb
@@ -47,6 +47,7 @@ class Chef
         hash['source']['name'] = new_resource.name
         hash['source']['description'] = new_resource.description unless new_resource.description.nil?
         hash['source']['category'] = new_resource.category unless new_resource.category.nil?
+        hash['source']['fields'] = new_resource.fields unless new_resource.fields.nil?
         hash['source']['hostName'] = new_resource.host_name unless new_resource.host_name.nil?
         hash['source']['timeZone'] = new_resource.time_zone unless new_resource.time_zone.nil?
         hash['source']['automaticDateParsing'] = new_resource.automatic_date_parsing unless new_resource.automatic_date_parsing.nil?

--- a/libraries/resource_source.rb
+++ b/libraries/resource_source.rb
@@ -46,6 +46,7 @@ class Chef
       attribute :alive, kind_of: [TrueClass, FalseClass]
       attribute :cuttoff_timestamp, kind_of: String
       attribute :cuttoff_relative_time, kind_of: String
+      attribute :fields, kind_of: [Hash, NilClass], default: nil
     end
   end
 end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -176,7 +176,7 @@ def sumo_service(action = :nothing) # rubocop:disable Metrics/AbcSize
 end
 
 # we should make this more effecient but lets get CI passing again so we can recieve contributions
-def installer_opts # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, CyclomaticComplexity
+def installer_opts # rubocop:disable Metrics/AbcSize
   args = []
   args << '-console'
   args << '-q'


### PR DESCRIPTION
## Pull Request Checklist

This is similar to #167 but in the context of a source rather than a collector. This is the same as #188 other than it uses a more up to date source.

#### General

- [ ] Remove any versioning you did yourself if applicable

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/) with all new changes under `## [Unreleased]` and using a `### Added, Fixed, Changed, or Breaking Change` sub-header.

- [ ] Update README with any necessary changes

- [ ] RuboCop passes

- [ ] Foodcritic passes

- [ ] Existing tests pass


#### Purpose

Allow specifying `fields` on sources per: https://help.sumologic.com/03Send-Data/Sources/03Use-JSON-to-Configure-Sources

#### Known Compatibility Issues
