### PR TITLE
allow the ability to cleanup previously configured local sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
+## [Unreleased]
+### Added
+- new `action` of `:remove` to cleanup sumo collectors [#191]
+
 ## [1.7.0] - 2022-05-11
 ### Added
 - feat: add JSON support to windows sources [#193]

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ sumo_source_local_file
 `default` = `:create`
 
 - `:create` - creates a JSON Source configuration
+- `:remove` - removes a previously configured JSON source configuration
 
 ### Attribute Parameters
 

--- a/libraries/provider_source.rb
+++ b/libraries/provider_source.rb
@@ -35,6 +35,12 @@ class Chef
         end
       end
 
+      action :remove do
+        file source_json_path do
+          action :delete
+        end
+      end
+
       def api_version
         'v1'
       end

--- a/libraries/resource_source.rb
+++ b/libraries/resource_source.rb
@@ -10,7 +10,7 @@ class Chef
 
       default_action :create
 
-      actions :create
+      actions :create, :remove
 
       attribute :owner, regex: Chef::Config[:user_valid_regex]
       attribute :group, regex: Chef::Config[:group_valid_regex]


### PR DESCRIPTION
#### General

- [x] Remove any versioning you did yourself if applicable

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/) with all new changes under `## [Unreleased]` and using a `### Added, Fixed, Changed, or Breaking Change` sub-header.

- [x] Update README with any necessary changes

- [x] RuboCop passes

- [x] Foodcritic passes

- [x] Existing tests pass


#### Purpose

In some cases even if temporarily one may want to remove a source from being ingested into sumologic. In other cases it's cleaning up dead code for something that no longer generates logs in the environment.

#### Known Compatibility Issues

None