### PR TITLE
Feature/windows json format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keep
 
 ## [1.6.3] - 2022-05-05
 ### Added
-- added Windows JSON support `eventFormat`,`eventMessage`,`allowlist`,`denylist` support to sources (@rjury-sumo) [#187]
+- added Windows JSON support to sources (@rjury-sumo) [#187]
 
-[#189]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/issues/187
+[#187]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/issues/187
 
 ## [1.6.2] - 2022-01-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
+## [1.6.3] - 2022-05-05
+### Added
+- added Windows JSON support `eventFormat`,`eventMessage`,`allowlist`,`denylist` support to sources (@rjury-sumo) [#187]
+
+[#189]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/issues/187
+
 ## [1.6.2] - 2022-01-05
 ### Added
 - added `fields` support to sources (@majormoses) [#189]

--- a/README.md
+++ b/README.md
@@ -381,6 +381,10 @@ The following attribute parameters are in addition to the generic parameters
 listed above.
 
 - `log_names` - **required**
+- `eventFormat` - 0 for legacy format or 1 for JSON format
+- `eventMessage` - Use with JSON format. 0 Complete, 1 Message (recommended), 2 metadata only.
+- `allowlist` - Available in Collector version 19.351-4 and later. A comma-separated list of event IDs.
+- `denylist` - Available in Collector version 19.351-4 and later. A comma-separated list of event IDs.
 
 ### Examples
 
@@ -388,6 +392,17 @@ listed above.
 sumo_source_local_windows_event_log 'local_win_event_log' do
   source_json_directory node['sumologic']['sumo_json_path']
   log_names ['security', 'application']
+end
+```
+
+Use JSON log format instead of legacy format.
+
+```ruby
+sumo_source_local_windows_event_log 'local_win_event_log' do
+  source_json_directory node['sumologic']['sumo_json_path']
+  log_names ['security', 'application']
+  eventFormat 1
+  eventMessage 1
 end
 ```
 

--- a/libraries/provider_source.rb
+++ b/libraries/provider_source.rb
@@ -60,6 +60,10 @@ class Chef
         hash['source']['alive'] = new_resource.alive unless new_resource.alive.nil?
         hash['source']['cutoffTimestamp'] = new_resource.cuttoff_timestamp unless new_resource.cuttoff_timestamp.nil?
         hash['source']['cutoffRelativeTime'] = new_resource.cuttoff_relative_time unless new_resource.cuttoff_relative_time.nil?
+        hash['source']['eventFormat'] = new_resource.eventFormat unless new_resource.eventFormat.nil?
+        hash['source']['eventMessage'] = new_resource.eventMessage unless new_resource.eventMessage.nil?
+        hash['source']['allowlist'] = new_resource.allowlist unless new_resource.allowlist.nil?
+        hash['source']['denylist'] = new_resource.denylist unless new_resource.denylist.nil?
         hash
       end
 

--- a/libraries/resource_source.rb
+++ b/libraries/resource_source.rb
@@ -47,6 +47,10 @@ class Chef
       attribute :cuttoff_timestamp, kind_of: String
       attribute :cuttoff_relative_time, kind_of: String
       attribute :fields, kind_of: [Hash, NilClass], default: nil
+      attribute :eventFormat, kind_of: Integer
+      attribute :eventMessage, kind_of: Integer
+      attribute :allowlist, kind_of: String
+      attribute :denylist, kind_of: String
     end
   end
 end


### PR DESCRIPTION
## Pull Request Checklist
Resolves open issue that there is no windows JSON support in windows events source. Closes #187 

#### General

- [x] Remove any versioning you did yourself if applicable

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/) with all new changes under `## [Unreleased]` and using a `### Added, Fixed, Changed, or Breaking Change` sub-header.

- [x] Update README with any necessary changes

- [ ] RuboCop passes

- [ ] Foodcritic passes

- [ ] Existing tests pass


#### Purpose
The chef cookbook only has support for legacy windows format.  This PR adds four new optional attributes to JSON source provider to support customers wanting to collect windows JSON format instead of legacy format.

#### Known Compatibility Issues
Should be none since there is no change to existing sources as the new attributes on the source are optional. It's worth considering at some point whether JSON format with 1 for eventMessage should be the default for the cookbook since  the recommended default for new agent deployments, especially for customers using Cloud SIEM Enterprise.
