### PR TITLE
Use correct rpm URL for aarch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keep
 ## [Unreleased]
 ### Added
 - new `action` of `:remove` to cleanup sumo collectors [#191]
+- Support arm (aarch64) rpm installation
 
 ## [1.7.0] - 2022-05-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keep
 ## [Unreleased]
 ### Added
 - new `action` of `:remove` to cleanup sumo collectors [#191]
-- Support arm (aarch64) rpm installation
+- Support arm (aarch64) rpm installation [#196]
 
 ## [1.7.0] - 2022-05-11
 ### Added

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -68,7 +68,7 @@ default['sumologic']['collectorTarUrl'] = 'https://collectors.sumologic.com/rest
 default['sumologic']['collectorTarName'] = 'sumocollector.tar.gz'
 
 # RPMs
-default['sumologic']['collectorRPMUrl'] = 'https://collectors.sumologic.com/rest/download/rpm/64'
+default['sumologic']['collectorRPMUrl'] = node['kernel']['machine'] == 'aarch64' ? 'https://collectors.sumologic.com/rest/download/rpm/aarch/64' : 'https://collectors.sumologic.com/rest/download/rpm/64'
 # DEB
 default['sumologic']['collectorDEBUrl'] = 'https://collectors.sumologic.com/rest/download/deb/64'
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No

#### General

- [x] Remove any versioning you did yourself if applicable

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/) with all new changes under `## [Unreleased]` and using a `### Added, Fixed, Changed, or Breaking Change` sub-header.

- [x] Update README with any necessary changes

- [ ] RuboCop passes

- [ ] Foodcritic passes

- [ ] Existing tests pass


#### Purpose

Running the current recipe on aarch64 would fail when installing the rpm. This change updates the URL so when the client arch is aarch64, the rpm URL for aarch64 is used.

#### Known Compatibility Issues
