### PR TITLE
Add arch64 conditional to support arm for debian installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keep
 ### Added
 - Support arm (aarch64) Debian installation [#198]
 
+[#198]: https://github.com/SumoLogic/sumologic-collector-chef-cookbook/pull/198
+
 ## [1.8.0] - 2024-01-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG (now) follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
+## [Unreleased]
+### Added
+- Support arm (aarch64) Debian installation [#198]
+
 ## [1.8.0] - 2024-01-12
 
 ### Added

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -70,7 +70,7 @@ default['sumologic']['collectorTarName'] = 'sumocollector.tar.gz'
 # RPMs
 default['sumologic']['collectorRPMUrl'] = node['kernel']['machine'] == 'aarch64' ? 'https://collectors.sumologic.com/rest/download/rpm/aarch/64' : 'https://collectors.sumologic.com/rest/download/rpm/64'
 # DEB
-default['sumologic']['collectorDEBUrl'] = 'https://collectors.sumologic.com/rest/download/deb/64'
+default['sumologic']['collectorDEBUrl'] = node['kernel']['machine'] == 'aarch64' ? 'https://collectors.sumologic.com/rest/download/deb/aarch/64' : 'https://collectors.sumologic.com/rest/download/deb/64'
 
 # Platform Specific Attributes
 case node['platform']


### PR DESCRIPTION
In reference to https://github.com/SumoLogic/sumologic-collector-chef-cookbook/issues/198

#### Purpose

Quick fix for Debian packages to support ARM images, much like issue #196 196 for RPMs

